### PR TITLE
add subset WH40k for WMT23 subtask: MT Test Suites

### DIFF
--- a/submissions/en-de/WH40k_WMT23/README.md
+++ b/submissions/en-de/WH40k_WMT23/README.md
@@ -1,0 +1,8 @@
+
+** TEST SUITE **
+
+Part of WH40k dataset - science fantasy (coming soon) 
+
+** PARTICIPANT INFORMATION **
+
+Pavel Stepachev, independent researcher, stepachev.pavel at gmail.com

--- a/submissions/en-de/WH40k_WMT23/WH40k_HHP_EN.txt
+++ b/submissions/en-de/WH40k_WMT23/WH40k_HHP_EN.txt
@@ -1,0 +1,2000 @@
+The Night Haunter waited for his father’s response to his joke.
+Kellephon was kinder than the others, and Fortreidon was glad of his proximity.
+‘I admit, I had not expected you to return so early, Miltiades,’ said the tyrant.
+The Nidhoggur’s void shields crackled into nothingness, and the gunships shot out into open space.
+That left Hymor and me, and we pressed on eastwards towards Hydana at the best pace we could manage.
+‘The command bears the seal of the Imperial governor,’ said Tessza.
+Warriors in tall helms and golden armour were arrayed behind the Emperor.
+‘I thought I gave orders that the patricians weren’t to be harmed.’
+The impact threw Ahriman from his vision and he cried out as a hideous sensation of vertigo blurred his vision.
+Elsewhere in the diorama were three-headed chimerae, ocean krakens and other legendary beasts of Medusa.
+In the end the Great Crusade is all, and it stands or falls by our actions.’
+There can only ever be one future, thought the Night Haunter.
+Had he not been so close, Nairo might have missed Lorgar’s whispered question.
+‘There is something stately about them, don’t you agree?’ asked Chancellor Corynth.
+‘That is the first aspect of the Truth you must understand, Lorgar,’ Kor Phaeron replied.
+To have an entire Chapter adopting that name should give us pause.
+Lorgar looked as though he might protest but Kor Phaeron’s glare forestalled any dissent.
+The Kingwyrm was neither worm nor serpent nor drake, not any creature depicted in the histories and bestiaries that Lorgar had translated for Kor Phaeron.
+‘This planet refuses to cooperate,’ Caelius said, echoing Numeon’s thoughts as they charged into the crater.
+As the years went by and the injustices piled up, the stories of Lycaeus were told with increasing bitterness.
+Six separate Imperial Army battle groups were making their final landings.
+Across the entirety of the XII Legion fleet, a single order was given.
+Nothing was destroyed or damaged, and with enough time and patience, a Techmarine could have rebuilt the tank.
+Gahlan set the slate down carefully, returning his full attention to Mago.
+But now, with your work and the actions of our forges on Nocturne, this ship will do so much more.
+‘The Thousand Sons are sometimes guilty of hubris, for we are seekers after truth and such a quest sometimes requires us to set ourselves apart from our brothers.’
+He had meant to take his cue from the Iron Hands around him, but the act of obeisance was instinctual, the only rational recourse to the presence of a demi-god.
+A hololithic representation of Antaeum and the ork vessels dominated the tacticarium table.
+Abdemon put it down to that old Europan ruthlessness – an instinctual assumption of superiority that the ancient aristocratic lines, in particular, seemed possessed of.
+Like command squads from any Legion, Agapito’s bodyguard had armour festooned with honours, embellishment and crests.
+The slaves and remaining converts stayed watching until long after Lorgar had been swallowed by the haze of distance and the wind had erased his footprints.
+You baited us, allowed us to kill men loyal to you, to Pandion, in order to draw us in.
+I have lived all my life as well as I could.’
+Even Perturabo, who is perhaps the humblest of us all, is not without his vanity.
+Miltiades grasped Perturabo’s shoulder and pushed down to force the boy to kneel.
+That they’d almost carved Cyrius out of his armour was proof enough of that.
+‘Numeon,’ he said, forgetting that Xerexenia was controlling the communications, ‘can you hear me?’
+He let the anger rasp through his lips as he gave the final order, the order that would forever more become synonymous with the compliance of the Gardinaal.
+So many explosives had been detonated in the planet’s air that it would take decades of Mechanicum scrubbers to make it even vaguely safe to breathe.
+He sat back into his throne and stared at the leaders of the Thousand Moons.
+The Flamewrought and its escorts were coming in an unnaturally tight formation.
+The Great Crusade was a vision of supreme ambition, one that would take father and sons to the uttermost corners of the galaxy for decades, perhaps even centuries.
+He breathed in the musty air, and its flavour reminded him of something far off and semi-forgotten, as if from childhood, except that his childhood had been experienced a long way from Terra.
+His blood was a contract between Chemos and its people, unbreakable.
+‘My lord, you relieved us of one terror only to replace it with one greater!’ protested Didimus.
+The most acute of all knew that his true form was almost certainly a mystery to all but himself and perhaps the Father who had created him, and that the projection was, for all its incomparable art, just that.
+Fabius stood in his apothecarium, eyes closed, seemingly enraptured by the quiet rhythms of a Terran concerto.
+The Iron Warriors gunship threaded the needle of the worst storms, surviving thanks to a mixture of near real-time data from Magos Tancorix and Perturabo’s phenomenal skill as a pilot.
+‘I will only be happy when we are home again, Khagan.’
+This punishment for treachery must be borne, but I will rebuild Olympia.’
+I speak to you as your warleader, master of this fleet and primarch of the Iron Warriors, appointed by the Emperor himself to this position and entrusted with the prosecution of this war.
+He had taken three more strides when Lorgar’s quiet command halted him.
+If you wish to know his purpose, look no further than the walls and spires of Vharadesh.
+‘We’re living in a golden age,’ Harik Morn had said, a wetness in his eye, as he broke open the consignment from Mars.
+But if I have learned one thing at all, it is that the march upcountry­ is often the most difficult.’
+Suddenly Angron reared from his hunch to full height, his face turned upwards, and he laughed.
+‘I should admire Him more, I know,’ the Khan said, pensively.
+However, it would be far harder for me to achieve my own objectives if the Dark Angels made it clear they did not wish for us to be anywhere near them.
+When he turned to look at Forrix, the primarch’s decision was written across his face.
+‘The city,’ said Forrix, who was watching everything from the main deck level.
+However, never let it be said that the Lion is without subtlety in this regard, for he too can judge his interactions with finesse.
+The ork responded to his taunt with fury, but there was a desperation in its charge, and again Vulkan thought it was the fear of something else, rather than anger at him, that pushed it forwards.
+Perturabo’s armour was still bloody from the fighting in the Sharei Maveth and still radiated heat from action.
+Hathor Maat stood at the edge of what looked like an elevator shaft for bringing vehicles up from a subterranean hangar.
+‘I fervently wish that your plan works, my lord,’ said Fenc.
+Caphen’s look, even through the frosted amethyst of his helmet lenses, was one that DuCaine had come to recognise all too well over the last century and a half.
+The Iron Hands legionary that opposed him could not have been more different.
+The Apothecary extended a bloodied claw towards the pinned-back wings of the mortal’s cranium.
+It had taken all Magnus’ considerable powers of persuasion to convince Perturabo to abandon his fortress.
+A time after Pexx had been incarcerated – how long was impossible to gauge – the door lock clunked.
+‘You are certainly not a beginner,’ Malcador said appraisingly, when the game had concluded.
+That was Magos Kunitax of the Mechanicum, one of the Legion’s primary allies amongst the Martian priesthood.
+The Alpha Legion is hereby considered part of the Third Rangdan War.
+Abdemon was right: Fabius had grown too comfortable in his web, outside of all authority.
+And, yes, I have seen those that do not return from the wilds.
+‘Amon spoke to me of your great victory at Gorro, father,’ said the Lion, eyes hooded, voice neutral.
+The path of slaughter leading to the real inhabitants of Ghenna was an unbroken chain of brutalised false humanity.
+But what the Ultramarines knew in their blood, Guilliman had ensured was also a direct, conscious, ever-present truth.
+The soldiers working on the tanks saw him coming and their reaction told Forrix everything he needed to know about their intent.
+In my father’s librarium there is a near complete folio of The Art of War.
+‘I am told that the Imperium encompasses a thousand stars,’ Dekka murmured.
+His canopy armourglass struck that of the Gardinaal, and for a snapshot of time Moses stared into the dark-tinted visor of a Gardinaal pilot.
+Lit by pale white light, Gholghis’ grey rock made for a confusing landscape where shadow and stone were difficult to tell apart, as if the planet had camouflaged itself in order to hide.
+Where Fulgrim was contemplative and beatific, he was belligerent and headstrong.
+He guessed that somehow he, not Guilliman, was the one who was meant to be acquiring new information, or new understanding, from the dialogue.
+Torn electrics and microfluidics bled onto the back of his neck as Savine placed a cold palm on his head.
+To speak of Kor Phaeron’s tyranny, to lament his beliefs directly would be to speak against the Word and the Truth – concepts in which Lorgar was fully invested despite his suffering under those convictions.
+Even those born of Chemos were not immune to the malignant imperfection.
+He knew what it was even before he saw the look of chagrin in T’kell’s eyes.
+The master had been right – the Powers had set Lorgar upon this world for a purpose.
+Skorr would do it, I knew that much, but his team would not be able to get here immediately.
+Orlov knew it was pointless to argue with Tancorix, but couldn’t help himself.
+He thrust the book towards Lorgar, who looked at it with surprise and bafflement for a moment before he took it.
+‘Our network has received rumours of a being sighted some way from here, in the galactic north-east – a being which appears to bear the characteristics of a primarch,’ Dynat informed us all.
+Corax’s astropath primus was present, as was the Navigator of the Saviour in Shadow, his fleet logisticians, four ship­masters of his capital ships, and the heads of several auxiliary regiments, the chief of which was named as Caius Valerius, praefector of the Therion Cohort.
+She had thought as much earlier, before Corynth had convinced Fulgrim otherwise.
+‘You have read them, yes, I could have guessed,’ said another priest.
+‘I have a shot,’ confirmed Jorin, his voice distorted in fury.
+‘They did not mean to, but the orks shielded us from the worst of the blast,’ Numeon said.
+And so while the Legion, and those few humans sufficiently strong of will to resist, were engaged suppressing a thousand insignificant acts of anarchy and mayhem, half a dozen small but growing forces converged, as if by conscious command, on critical sections of the ship.
+This was all Perturabo could see of his actions’ consequences, a small gap in the fortifications he had surrounded himself with.
+‘All pyramids are currently under attack on two fronts,’ Habron said.
+From what Aravain had been able to glean, the creature that Corax had slain had been an engorged and physically atrophied specimen, already on the wane having exhausted the psychic resources of its world.
+There are worlds where the worst possible things you can imagine happen as a matter of course, things that make the horrors of the Red Level seem mundane and kind.
+He had not then met a man to whom he was not related, much less heard one speak another language, before the Legion recruiter had come to take him to Aldurukh.
+‘Are you prepared?’ asked Korit, his voice harshened by the grille of his snarling crimson helm.
+Everything about him – the way he looked, the way he fought, his poise and his resilience – spoke of a son of the Altak.
+‘I did what I could with what we have available here.’
+Despite his stern demeanour, Skraivok was eager, infused with energy, in marked contrast to the dour warrior who stood guard at his back.
+The Tyrant struggled to his feet then, swaying unsteadily over the throne and supporting himself with switch-thin arms.
+Deploy another two companies from the Legion to replace them, and as much auxilia support as they require.
+Though his view should often have been obscured by the overhanging crags of the unclimbable peak, Perturabo could see his father no matter where he was.
+The Gubernatorial Throne had once had access to an impressive intelligence network, but its reach and resources had been slowly whittled away by the patricians.
+The situation upon the planet’s surface is unfortunate, but now you have returned I believe it can be resolved swiftly.
+‘You are here at the command of the lords of Nostramo, chosen for your murderous and pitiless natures,’ he said.
+‘What is the point in being commanders if we follow orders blindly?’ said Agapito.
+Perhaps a hundred metres of clear air separated the Lux Ferem from the ground.
+‘I could feel your existence, of course,’ Omegon said to me.
+He spoke the words with the same inflection as Kor Phaeron, perfectly mimicking the emphasis the priest placed upon them.
+Or did Akurduana read too much into a mere reflection of the light?
+Amid the squares of soldiers awaiting inspection by Dammekos, three dozen war machines of Perturabo’s own design idled their engines.
+Shamefully, he stopped shooting, waiting for Zankator or Fan to finish the deed for him.
+‘Steady now, keep the advance!’ bellowed Mago, his spear never ceasing.
+In this regard, our Legion is the foremost of all in trustworthiness.
+Faster than eyes could track, Mago had the blade of his spear at Ohna’s throat.
+‘We need to get them moving faster,’ said Ahriman’s armoured companion on the other side of the street.
+‘Where did that strike come from?’ demanded Russ, striding to the edge of the command platform, unwilling to believe the evidence of his senses.
+His skills, already potent, had been further honed by Tesserius Akurduana, a warrior reckoned the finest swordsman in the Legion.
+Did he truly believe the brightest minds of the Thousand Sons had not already debated this thought experiment a hundred times over?
+‘Perhaps were it not for the machinations of the Achaens, we would not be in this woeful situation!’ retorted Didimus.
+But always he had attested to the plans of the Powers and how they acted through him.
+‘I can try, lord,’ Gukul replied grimly, which was all the information I needed.
+‘It was to demonstrate my Legion’s prowess, and by reflection my prowess.’
+I had purchased it from a manufacturer of such goods not far from Winnika’s depot, then cut it down to size.
+‘The problem with that,’ as Russ had once explained to his brother Vulkan, ‘is that we like being angry.
+The glory of the Truth does not die today on some unmarked field of sand and dirt!
+The immense armature of his Cataphractii plate glittered with trembling droplets of condensed vapour.
+Lion El’Jonson was a mighty general, and he would want to assess this new development in the Great Crusade as soon as possible.
+Nairo saw several parchments covered in the neat cuneiform he knew to be Lorgar’s script.
+The patricians might have accepted Corynth as regent, but they would never accept an elected body of malcontents.
+They were of the Kushtun Naganda regiments, and might have fought alongside my father, or at least in the same conflicts He had.
+‘You cannot live your life alone, my son,’ said Dammekos sadly.
+‘You have given him the authority to run all of Vharadesh in your absence.’
+The Night Lords had another name for the planet, bestowed with a Nostraman flair for poetry, and that was the Carrion World.
+Although I had felt kinship of a sort when I had laid eyes on those found so far – all without their knowledge – I had not yet discovered the one whose soul I could feel was bonded to my own.
+Unlike the human woman’s, Aravain’s vocal cords were scarcely perturbed by the gunship’s vibrations.
+What did keep his attention was the stone around him – it was old, terrifyingly old, sunk into the bedrock long before the spires and domes that now formed the outer profile of the Palace were built.
+Nairo could see the glint of weapons – spears for the most part, nothing advanced – but the arrangement of the Declined suggested curiosity more than hostility.
+Other Legions, I believe, view it as offensive that my Legion take on not just my appearance when dealing with outsiders, but also my name.
+His armour was covered in reddish stains, and Fulgrim wondered whether the wounded had appreciated the attentions of the Apothecary, or whether they’d have preferred the ministrations of the merely human.
+‘Now is the time, Leman of the Russ,’ the Wanderer said, in the voice that was both young and old, masculine and feminine, always soft, suffused with a patina of epochal sadness.
+‘We are captains of the Twenty-second, and we will prove what that means.’
+Jorin didn’t reflect on that as he entered the crew bay of the Haukr, some hundred metres below the command bridge.
+The stippled, Dark Age ruins of the islands’ fortifications had been extended with the harsh features of gothic architecture.
+I am better than you because I saw that clearly, without your naivety.’
+Some innate ability, psychic in nature, Corax surmised, blocked out his presence from the minds of humans and most xenos.
+Their looks of fear and the reactions of his sons cleared Perturabo’s mind.
+Elver unwittingly caught his gaze, and, perhaps due to Elver’s hidden gift, a flash of understanding passed between them.
+The warp currents are smooth, and I can see no impending problems.’
+He had learned the war-rhythms from the Sulpha in his youth.
+Now he stood, alone, in the presence of the Lord of Winter and War.
+He dug his fingers into the earth, drawing out a handful of Ghenna’s dark soil.
+‘Prospero is a place of… mixed emotion for me,’ said Ahriman, startling himself with his need for honesty.
+Yet secrecy is of the utmost importance, I hope you will understand.
+Thus, he had done his best to quash all hint of wrongdoing on Fabius’ part.
+The Khan drew in a long breath, pulling the cold air of Chogoris deep into his lungs.
+‘The Fourth and Fifteenth Legion fleets comprise enough civilian craft to accommodate between forty and sixty thousand evacuees per vessel.
+‘They are the leaders of the Great Crusade, crafted from the Emperor’s own genetic stock to embody a different facet of his personality and the demands of war.
+Night Haunter was unworried; no infection could harm him, he knew this instinctively as he knew so many other things.
+Perturabo had the Cavea Ferrum installed beneath the smoking ruins of Kardis, his labyrinthine lair of iron halls and subtle energy fields that could misdirect any intruder.
+‘You wish to expunge all evidence of our faith from the Legion?’
+I panted from the exertion, but I was still not done.
+This was true as well, since I had not sought consent from either of them.
+The intensity of my expression was so great that they both quailed before me, and I forced myself to relax.
+He glowered at the screens as Legion markers poured through the capitolis walls.
+We did not know what wounds or illnesses the refugees might have suffered before arriving here, and it was already obvious that, at this stage at least, the infrastructure of Volda Beta was not capable of meeting their needs.
+My father had greeted my rediscovery with wonder; Malcador, with intrigue and some satisfaction.
+‘I have acquired a new world for the Imperium, at minimal cost, and a new source for potential aspirants for my Legion.
+‘That is kind of the idea,’ said Skraivok, again to great approval.
+‘It is no comfort that he will die a slow death instead,’ moaned Axata.
+Bucepholos may have been behind one or more of the recent attempts on Pandion’s life.
+‘Perhaps,’ said Ashkali, bending to draw a circle in the dust with her fingertip.
+Any trace of the amusement Angron had expressed moments before had vanished.
+‘You can always come to me, you know this?’ said Russ.
+‘It seems that the Third Legion has much to teach us.’
+‘I am sure the Emperor has His own ideas on ruling the galaxy fairly,’ said Corax.
+He carried a naked dao blade, as long as a man’s height, engraved with ancient Khorchin battle-curses.
+With an effort that almost made him black out again, Vaughn turned his eyes to the right and saw the first captain.
+This simple fact made them more fervent followers, with the vigour of those whose existence now depended upon the Truth of the Word to give their lives meaning.
+She had fought so long for the XVIII Legion, and had been through so many desperate struggles, that she had a taste for the last stand too.
+As far as the Sak’trada Deeps were concerned, miserable Gholghis was a paradise.
+We have determined, through our study of the signal it was broadcasting as well as their anatomy, that the Ghennans are not merely autonomous machines masquerading as humanity.
+‘If you cannot accept simple instruction I will not waste my time with you.
+You are to relinquish command immediately to your lieutenants and report to me aboard the Iron Blood.’
+I never got the impression He understood such things, but then again it is dangerously easy to underestimate Him.’
+You think He’s too close and driven by plans He does not divulge.
+In a xenos enemy, Jorin might have respected the continued defiance, for it was natural instinct for any organism to defend its own, but there could be no respect for the Tyrant of Dulan’s armies.
+Even when she did manage to approach one they would tell her almost nothing; sometimes even getting their name and rank felt like prising the darkest secret in the Imperium from its sworn protectors.
+The Khan reached for a goblet and poured himself a drink.
+‘Witness the Truth from my lips and remember the name of Kor Phaeron!’
+Though his attention was elsewhere, Kor Phaeron did not think he was listening to the universal music that filled his thoughts.
+This, however, was fleet warfare, and the xenos had no chance against the precision strikes and group tactics of my Legion.
+He was fighting the Elemental of Karaashi through a maze of ice.
+Perturabo and a dozen of his warriors watched from his elevated workshop, and Magnus winced as he climbed the steps to meet his brother.
+‘Theoretical – if this fortress and its tunnels are what the culture of Thoas became, then this was a civilisation devoted entirely to war.
+‘Yes,’ I replied through gritted teeth, rising back to my feet.
+Against all effort to remain aloof and scholarly, a teacher not a parent, Kor Phaeron could not restrain the growing paternal instincts that Lorgar aroused in him.
+A full company of legionaries joined Vulkan on the roof of the hull.
+By their position, Forrix knew the cities, but his brain was numbed by the slaughter, and when he tried to recall their names they swam away from his mind, like fish evading capture.
+‘I fear that I will be forced to draw this blade in anger.
+She reassembled the Aegypta’s navy, using it to re-establish their old empire, and launched military campaigns against the nations who had once been their oppressors.’
+‘The Wolves razed my world and burned our knowledge to ash!
+They celebrated the XVIII Legion and the history of the device.
+‘And I am guilty, just as you are,’ the Lion urged again, his grip on the sword tight.
+The workings of a Hydra were no mystery to Forrix; an Iron Warrior could operate any artillery piece in the Imperial armoury.
+The voice in the chamber only spoke his own fears aloud, he knew that; he knew it wasn’t the Emperor, as much as he knew it was.
+Each of the gladiators is an abhuman giant, equal to Angron in size.
+The XII Legion phalanx was a devastating force on any battlefield, often imitated but never bested.
+We can discuss the war, and we can join our forces to combine their strengths, just as our father intended when He made us all so… different.
+He couldn’t know for sure that every Morningstar soldier was hostile, but the Iron Warriors operated a zero-uncertainty policy within their perimeters.
+Of all the blazes Kor Phaeron had witnessed of late, this was the crowning moment.
+Delicate scrollwork marked the flat panes of ceramite, depicting scenes from Chemos’ history.
+‘You thought the end of the waiting would be the end of doubts,’ Vulkan said, as he joined Rhy’tan.
+‘Malcador tells me you have made significant progress with your studies,’ He said, as we left my quarters and began to walk through the Imperial Palace.
+Do not take my levity to heart – I wish this to succeed.
+Their return to Gardinaal Prime would see the institutes of Human Resourcing ensure that their stripped flesh and ground bones provided one final service to the state.
+The fires consuming Malkoya, though, were still raging when word reached Angron from the fleet in orbit.
+Upon these walls were battle companies of Iron Warriors, who now patrolled as if the city were an embattled outpost.
+Under magnification, they were marvellous landscapes of the worlds Agapito had visited in his career, forty-nine thus far.
+Unfortunately Kor Phaeron had never seen the original text on which the book remarked, but he had inferred much of Dammas Dar’s observations nonetheless.
+By the time legionaries of the First Chapter arrived with Marius Gage, there was nothing left to kill.
+‘I wonder how many ships called Terra’s Glory there are in the galaxy?’ mused Autilon Skorr.
+‘Do you think,’ Russ said, mulling the matter over in his mind, ‘that Malcador knew we would meet here?’
+And you are sure enough of your position to stand before me and tell me that you will not do what I ask?’
+But I trusted too much to human nature, as you made me to, as the universe dictated I do.
+Solemnly, Curze passed into his arming chambers, where sombre, tongueless slaves awaited him.
+The tallest spires of Zharrukin swayed and groaned, the re­inforcement within the stone tearing as alternating fields of powerful magnetics twisted them.
+The men destroying his Legion from within were either confident they would not be discovered, or were so proud of their actions they felt they had nothing to hide.
+It was peaceful here, in contrast to the rest of Byzas.
+But I know well enough that, for all our glory, we are but a backwater province of a far greater kingdom.
+‘Do you believe that even the First Expedition Fleet never suffers a casualty?’
+‘You say “hosts” but what you mean is the population of Muspel.’
+But to craft an image rather than simply recreate one, it is…’ His face contorted in an agony of frustration.
+He needed to stop Alkenex and Quin before they depopulated the entire barracks.
+On Chemos, he had been forced to navigate spheres of influence, as he slowly worked to break down and rebuild the old executive clan system.
+If he kept talking, he might give me information I would not have thought to ask about.
+He looked expectant at this witticism, and expected Kiner to share the joke.
+As he walked, he sent a second command, this time directed at the Legion garrison commanders rather than the ship-crews.
+The chatter died down a little and Vashti walked to the edge of the command centre, peering down onto the platforms through the vibrating armourglass.
+Of the one hundred and fifty-five legionaries under Santar’s command, only sixty were with him now.
+‘And it is the same in the other two warehouses?’ asked Caius.
+Two masked men in golden robes, with an Imperial Army-issue rocket launcher primed and ready to fire.
+‘But you waited until I was here to see you do it.
+If such disasters were not bad enough, Mechanicum theorists predicted an ultra-rapid erosion of Morningstar’s atmosphere, resulting in lethal exposure levels of stellar radiation.
+But I also know I was placed here for a reason, and you must know that I intend to carry out my duty.
+‘What do they say, brother?’ said Farith Redloss, nodding towards the slate in Duriel’s hand.
+‘They have no conception of the enemies we have overcome,’ said Corax.
+Let me hear in your march the beat of the great hammer of the Eighteenth Legion.
+But even now, with the Great Crusade having uncovered so much of that ancient knowledge, ignorance of the galaxy’s far expanses was near complete, with only rare oases of light, such as Ultramar or Terra, to break the remorseless dark.
+He would see the Dark Angel broken on the dust before the sunset, for now he understood the ritual, and what it meant, and why it had to continue.
+Nairo bowed his head in supplication while Hu Osys fell to her knees, forehead pressed to the flaking grey paint on the metal floor.
+‘I can draw down fire from heaven and scorch your cities to glass, if I wish.
+He could only see with the eyes of a member of the old order on Macragge.
+‘What happened to the man I knew who wished for no more war?
+She wore deep green robes and bore the stylised I-icon of the Imperium atop a long metal staff.
+This pointless, ruinous campaign was the fault of the Emperor’s vanity.
+He closed his eye, letting his mind absorb Shai-Tan’s pain, reliving it over and over through the memories of all those who had suffered here.
+The Golden One was not seeing anything in the physical realm, nor paying heed to the mortals who passed him, or the lick of the flames creeping closer and closer.
+And if he had drawn anything from his interrogation of Moses Trurakk, and from his present company, then it was that the Imperials were profoundly intolerant of weakness.
+His manner was so hypnotic Kiner saw the place in a new and glorious light.
+On the sixth Coldfall after Lorgar’s discovery Kor Phaeron consulted the heavenly messengers and asked them to provide guidance.
+‘I agree when you say you’re not an enforcer,’ said Tensat.
+The request was made quietly, but it entered Kor Phaeron’s thoughts with the same weight as the commands of the Powers themselves.
+Pride and duty held him here, not dedication to the welfare of the Imperium as a whole.
+He lost a few seconds, because Xerexenia was suddenly leaning over him, when she had been standing before her console, a few metres away, the moment before.
+‘Then we should look for answers in the ruins,’ Guilliman said.
+For a moment, I thought we had an understanding – that we had showed him what could be done – but then he pulled away.
+The Khan looked sceptical, studying Magnus for a long time, probing for some subterfuge or dissemblance.
+The orks were caught now between Iasus’ formation, Guilliman and Hierax’s company.
+The idea is worth exploring, and I am sure you would do a fine job,’ said Guilliman.
+She tucked the paper into the breast pocket of her coat and looked up at Amar.
+For the first time Elver could recall, the captain seemed cautious, even frightened.
+As they moved through the tents and caravans and into the city proper, Nairo was shocked by what he saw.
+The upper hundred metres of the tower exploded, as if an Elemental had just been born within.
+The trio of Stormbirds had landed on a massive, flat stone dais, many hundreds of metres across.
+‘I saw it,’ whispered Tethys, the low rasp of collapsed lungs.
+The echo of the Emperor’s words sent a shiver of dark prescience through Magnus.
+The belly of the Lux Ferem was a hundred metres above them.
+In a few seconds the blind cloud had enveloped the construct, the plasterbag stockade and the Ultramarines; even the wail of the tocsins became muted.
+For a moment, Dantioch thought that Perturabo would strike him dead there and then.
+‘Have you wondered why a pre-Imperial human planet did not have one already?’
+It was rendered deliberately small, partly for reasons of space, partly so that Corax might stare down at it from imperious heights.
+‘I shall bring a new creed, the Truth of the One.’
+It was all the momentum of the Termite, its monstrous totality – just as it was not the hammer itself that would crush an enemy, but the force of the blow.
+‘My time is limited, but while I draw breath, I will stay and provide a welcome for any of the xenos who come here in search of us.’
+‘There is a term in the Augean dialect of the Ionic Plateau – anabasis.
+I opened my mouth to order Everedd to withdraw, but something held me.
+‘We do not truly understand the warp,’ Omegon continued, ‘but it is not like the material universe in any way.’
+Let the Truth be your strength, and whatever becomes of this world know that your faith will prevail.
+Kor Phaeron considered dismissing the question but he could see that the matter would nag at the captain, and through him would infect the thoughts of the other converts.
+They raced towards their targets, but at the last second, Ahriman twisted their course and turned them back upon their source.
+‘What…’ The old man looks between the becalmed Jochura and Angron.
+He had fallen almost eighty years before Aravain’s ascension to the Legion.
+He had fought alongside the sons of three Legions in his time, and the thought that they might be to blame for the current predicament, even unknowing, was anathema.
+Not the battles since, but those on Fenris I never forget.
+There’s more than a few people believe that the Mechanicum is responsible for their misery.’
+Whether through instinct or some brutish version of strategy, the orks were tracking the Termite with greater accuracy now.
+His was a false smile; sometimes Perturabo regretted Harkor’s elevation to the Trident.
+Ilthen’s ruby eye lenses danced with the reflected light of hundreds of detonations blooming across the cloudy orb of Nostramo.
+A migration was building, almost certainly a reaction to the Iron Warriors’ presence in the sector.
+‘I will see you rise again, Cassian Vaughn, your strength the equal of your will.’
+The man turned round so fast Elver didn’t have time to blink.
+The Legion was courting one disaster in order to avert a greater one.
+The 125th Expeditionary Fleet was scattered across at least one astronomical unit of space or more.
+‘Justice is hard and cruel and I am hard and cruel!’ he snarled accusingly at the figure.
+He thought about Ranknar, and how close the war to bring that world into compliance had come to becoming a war of extermination.
+Take me there – I need to fill my lungs with purer air.’
+‘You at least, Camen Manek, are blessed with a little brain,’ Curze said.
+‘I had always assumed it was the soul of the one who made me, but now I see my error.’
+Even with such a warning in our ears, even having seen many strange and vile things in my time amongst the stars, I was not prepared for what rounded the corner.
+The army units in the western provinces and the agri-circle will put pressure on Bucepholos, forcing him to meet with the Sabazians, or risk fighting a war on two fronts.
+He took a sip from the cup and passed it to Kor Phaeron, who allowed only enough liquid to moisten his lips.
+They left the rest of the tens of thousands of Lorgar’s converts behind, to make camp away from sight of the city and its defenders.
+Curze could hear Elver’s heart from the other end of the vessel.
+He would use Sirras’ foolishness to reach his goal much sooner than would have been possible until now.
+Sometimes, he would spend time with Elver, and instruct him in various matters.
+‘And such things are impossible, or so our Father told me.’
+If the clerk noticed the croak in Grymn’s voice then he was too harried to remark on it.
+Duriel glanced at the prostrate form of the previous governor, then at the Lion.
+The Wanderer turned, looking out into the highlands of Asaheim, where the peaks marched under a crystal sky, eternal and inviolate.
+You will be taken from here and judged for your crimes, but your world will be received into the Imperium, its people preserved.’
+It had slender lines, as proportionate as everything constructed by the Blood Angels artificers, though also as heavily armed.
+‘What could be down there that is of interest to the primarch?’ asked Astakos.
+Corax thought of Sanguinius and Angron, Dorn and Guilliman, The Khan and the Wolf.
+Again Axata showed his understanding but betrayed further thought with his disturbed expression.
+Whether that lay in the artifice of the Emperor or the being of the Lion was unclear.
+Slowly, Angron looked back at Khârn, the absence of light doing nothing to dispel the intensity of his yellowed, glaring eyes.
+Half the corporal’s men had already left to delay the Imperial attack on the district power plant.
+Morningstar had been settled early in the golden age of exploration, and Zharrukin was one of its earliest cities.
+Autilon Skorr had his own features, as did Dercius and Sheed Ranko; but Eltan, Hymor, Jha-Tena, Ingo Pech, Silonius Kel and Thias Herzog all wore mirrors of my own face, or as near as made no difference.
+Like his Legion, they sought to attain a perfect state of grace.
+He could see his words sinking into the mind of Lorgar, and pushed home his message.
+‘We embarked on this endeavour to save the Emperor’s realm, not to watch it die.’
+The Dark Angels would assume that was a difference between us, and they would be mistaken.
+He had sought out the Forgemaster in his quarters, where T’kell had been preparing for embarkation, and told him that he would be the pilot of the great engine.
+The orks had managed to hold the Spear of Fire in the hall long enough to bring their weapons to bear.
+Six hours they had taken to reach the bastion’s inner command coil, two more to destroy the residual Scarabine suicide guard units, and then another two to sequence the plasma charges before lifting out.
+He’d heard similar sounds often enough on Chemos as a child.
+Clearly his sense of secrets buried in Zharrukin had been correct, but what danger had he sent his sons into?
+‘I heard all of your chatter as you approached the camp, and everything that has been said since I came aboard.
+The door slammed in Nairo’s face a moment before he heard a muffled low moaning, swiftly followed by indistinct words of comfort from Kor Phaeron.
+It was always hot in those armour sets, Caius remembered well from his days as a line officer, even though they had inbuilt cooling systems.
+The situation did not please Och’hi, but it did not surprise him.
+It fell back to Morningstar with infinite grace, but Forrix knew that something of such titanic mass would cause untold devastation upon impact.
+One of the Space Marines who had saved Dantioch staggered back into the line.
+‘He will bring doom on Lochos!’ said the priest, directly to the crowd.
+Though they were invisible to other human eyes, Corax could see his twelve warriors ranging high and far through the recycling plant’s structure.
+My lord, one of my sergeants, Zolan, insisted that I should consider withdrawal.
+Although I now lacked a pauldron and half my chestplate, the communications functions were still working properly.
+They claim they are our protectors, but I tell you they are daemons given human faces!
+That single statement soured the mood more than all the artillery of the III Legion ever could.
+He was the Eighth Assault Company captain, the equerry, the eyes and ears of the primarch.
+The Wolf King boasted to all that he was his father’s executioner.
+But when Guilliman arrived, he shamed Corax for his harsh judgment.
+The sensible ones noticed quickly that the Space Marines were not firing, and took shelter in the nests of seats.
+‘All I see is dust and smoke, and my eyes are far keener than yours.’
+Either his brain was more cunningly engineered than even a high consul of the Gardinaal could comprehend or he genuinely did not know.
+The Khan ran his hand over his face, rubbing at the scar that ran down his left cheek.
+Ove-Thost caught a glimpse of three rows of teeth, then a blast of foul breath and a splatter of yellow saliva.
+Of the ten commanders of the first ten Millennials of the Legion, he was perhaps the most thoughtful.
+‘Explain your analysis,’ Iasus said, more out of necessity than interest.
+The memory of the fight with the Cadere curdles and deforms, yet Tethys feels every sensation experienced by his father that day.
+The greater part of those garrisons was made up of the Auxilia regiments, though most had a skeleton Legion presence and access to rapid-response networks.
+My enemy is in our very blood and bone, and strikes where I least suspect, at every turn.’
+A whole Legion of Space Marines dedicated to the prosecution of the Powers’ goals, nestled in the heart of the Imperium’s efforts to conquer the galaxy.
+If the day ever comes, I will not be astonished at it.’
+Against this background of fear, Elver attempted to do his duties as best he could until, in the end, terror became mundane.
+‘It has been near a year and a half since I departed these walls.
+‘Cut me,’ he commanded her, ‘and release Perturabo’s blood, for my name is Perturabo.’
+‘I am saying I do not need you to explain the craft of war to me,’ said Pexx, punctuating his words with shots from his volkites.
+Next to him, Aladas gave him a pointed look, her eyes filled with doubt.
+His knees almost buckled, but with the help of the Land Raider behind him, they held.
+Smooth warp currents or otherwise, Arachmus was best off concentrating on his role rather than speaking with me.
+‘From the earliest days, before I understood anything but the Altak, I always knew where the threat lay, and how to counter it.’
+It was as if the Imperium were governed by the two faces of a single man – one preternaturally healthy, the other irredeemably sick.
+We will bring him before the Emperor, but we must do it ourselves.’
+It began to float towards me, but I ignored it for now in favour of the other warrior, which was already scuttling sideways to get a better line of fire.
+Barely functional was the expression that leapt to Vashti’s mind when she first saw her new working environment.
+His former captain, Garr of Order Quarii, had, to the relief of all, bellowed the news into the Hall.
+Fuggy heat hit a moist slap of sweat about Caius’ face.
+Kasperos Telmar and Grythan Thorn paced to either side of him, alert for any threat.
+To see someone as vital, so physically imposing as Lorgar in pain was dreadful.
+‘When I was younger I used to have so much fun.
+‘As I understand it this planet will fall in a week or two.
+‘The Emperor Thutmose the Third did not have his Dark Angels.’
+They failed to heed the call to join the Imperium, and so it was a forced compliance.
+It took us four hours to reach the outskirts of Hydana, but here our pace had to slow once more, for now we were at greater risk of discovery.
+Vel-Kheredar would wring every scrap of knowledge from here, and then he would burn it to the ground.
+He recognised her as Enith Forsault, a recruit from the more recent intake, but a promising one.
+Ultimately, though, it was Guilliman’s distaste for what the Destroyers were and did that held them at bay.
+‘If I spoke in here now, it would be a lie.’
+Fan Morgai, leader of the tribe, gathered his family to a brief council.
+I thought my crews were good, but I believe yours could school them.’
+Fenc stared at polished, chequerboard tiles, but he imagined Corax surveying the kneeling men.
+When I look at this painting, I am reminded again of why I insist upon perfection in every aspect of my Legion’s conduct in battle.
+Belleros Corynth, on the other hand, was a man of the people.
+Whereas the Emperor’s knowledge and mastery of all seems an innate part of Him, Malcador gives the impression of someone who has come by his wisdom through long study.
+Shield flares enveloped the morbid machine, but DuCaine could not tell if it had been damaged.
+‘Captain, I would cast this cargo out into the void, and forget you ever saw it.
+I have slain thousands in the name of the Imperium, but these feelings, my lord…’ He swallowed.
+Nairo had eyes only for the master – not out of any loyalty to Kor Phaeron, for he was a despicable man, but for fear of his own future.
+All the Iron Warriors’ logistical expertise was required to reform their battlegroup, but slowly the fleet regathered, and such repairs as could be made without orbital facilities were begun.
+In all the years since his elevation into the Legion, all the wars, he had known loss and defeat.
+It served your brothers who are now on Antaeum, and you have served it by remaking it stronger.
+Then he would order the next attack, knowing that he was set upon a course and to abandon his plan now would render every­thing undone, a failure to the One and the millions who now looked to him for spiritual guidance and leadership.
+If Fulgrim was the phoenix, then the Emperor was the fire that bestowed renewal.
+There were no measurable communications between the xenos worlds, nothing to indicate that they shared information at all, but shortly after the use of the temporal bomb on Gugann, the hrud had begun to move en masse.
+‘I wish I had more time to know you, Forrix,’ said Ahriman.
+At the time of its departure for the Taras Division the XVIII had only one battleship.
+He hadn’t been able to relay a message to Anastana and his sons in six months.
+The Lion pinned him beneath the weight of his regard a moment longer before releasing him.
+Sevatar glanced up to see the primarch’s eyelids flutter, and take an unsteady step back, signs the First Captain knew only too well.
+‘Might I formally request that you choose another in my place?’
+If the IX Legion had a flaw, Yesugei had decided, it was this unwearying enthusiasm for testing themselves in close combat.
+‘I spent my boyhood in the shadow of the great mountain of Eite Mòhr, but my heart is Olympian.
+Battle raged around the twin islands of calm that were Angron and Tethys, and Khârn and Mago.
+‘You are going to die,’ said Aravain, the taste of coagulated blood in his mouth, ‘in the manner of every tyrannical xenoform that stood in the path of humanity before you.’
+Sometimes I wonder if Jaghatai views the Imperium more as a means to get him to the stars than anything else, but that is of little concern.
+‘I swear by the almighty Powers that… I shall dedicate my life to learning the Word and the Truth, and to serve the Powers as they see fit to guide me.
+For the first time, and the last time, his foes would see a son of the Emperor unleashed.
+Sometimes ten thousand or twenty thousand of the Faithful were sacrificed against the defences of the unholy, yet he remembered them in his speeches and his dreams were haunted by their deaths.
+In the interim, I have received delegations from many of the factions.
+On the bridge of the Conqueror, three hundred souls moved in ordered anarchy as they orchestrated the XII Legion flagship and the fleet of warships that surrounded it.
+She had prospered under the tutelage and patronage of Lorgar, one of the handful of the original slaves of the caravan who still survived.
+But Thunder Warriors were no great secret, and this man’s anatomy did not match what I had learned of them.
+Guilliman had never made a secret of his distaste for Destroyer tactics.
+‘He,’ said Khârn coldly, ‘is our primarch, and we are his sons.
+‘I am the intermediary of Galithium Vo-Phoex, creator of this vessel.’
+If you will excuse me, I have other duties to perform.’
+Even among all the great works of architecture, mathematics and science that lay in ashes around him, this loss struck Magnus deeply.
+Many of the routes were blocked by rockfall, and Tarchus’ squad had to double back or choose alternative routes so many times that it became impossible to plan a systematic reconnaissance of the ruins.
+If Corax had violent intentions towards Curze and made the first move, then he’d definitely die.
+‘The truth, as one of Terran descent would say, is that such men are seldom given choices.
+Kasperos and the others looked every inch the demigods that the Emperor had intended them to be.
+Guilliman’s ear separated the roar of the orks from the roar of the Ultramarines.
+Squads that had never before heard of one another were thrown together into new attack groups, organised under the auspices of the general taken so recently from the Imperium’s Departmento Munitorum.
+Jorin was at the head of it, accompanied by Bulveye and his retinue, smashing their way through a labyrinth of burning, melting, sliding detritus.
+Guilliman had seen the look on Fulgrim’s face during their joint operations.
+‘And that is why I have entrusted the guard of this temple to you, my vigilant gun-deacon.
+He tried to run for the ladder but the other priests snatched hold of his robes and forced him back towards Kor Phaeron.
+The legionary was looking over the tent’s wounded, eyes trembling with a force of compassion that even Cicerus had never shown for his mortal soldiers.
+‘What by the Throne of the beloved Emperor is going on?’ he shouted.
+The Termite was armed, but its lascannons and twin-linked heavy bolters, which would be devastating against infantry and armour on the ground, were futile against a void ship.
+This was a good thing, because with the unprovoked attack on Kardis, they now had a great many foes.
+‘If Lorgar is a prophet, nobody will control him, none but the Powers.’
+Numeon and Orasus had kept to within a few metres of Vulkan during the entire rout.
+The Covenant Militarum gave a regiment’s commanding officer ultimate responsibility for the individuals in his regiment.
+There was little doubt what his role was, at least to anyone who had seen the Wolves fight.
+However, by some means, Gharluk had nevertheless tightened his grip on an entire subsector, maintaining communications between worlds and organising offensive raids across multiple battlefronts.
+The lights were closing on me now, and I could hear, above the wind, the mechanical roar of an engine.
+To the men and officers of his Legion and their allied fleet and army personnel, the reasons for his choices were moot.
+‘Not all of us are so without friends in the Palace, Leman, and you have no idea who our father favours.’
+The Gardinaal had not faced a military threat in twenty-five hundred years.
+Give my Chaplains and enigmatus cabals a week, sire, and I will have the solution you require.’
+Though he could only hear two words out of every three, it was obvious that the argument was not turning in Kor Phaeron’s favour.
+Several of my brothers – Ferrus, Mortarion, Perturabo, even Russ – would have taken the enemy’s strength as a challenge, and met it head-on.
+The Apothecary had striven against impossible odds for so long that all he could see was the fight.
+He moved to fill it again, for the boy, but Kor Phaeron shook his head.
+The cold stone walls reminded him of Aldurukh and the home he had forsaken in favour of duty.
+The primarch called up the manifests and fleet registries for the Legion ships anchored within the upper atmosphere.
+I have watched Sanguinius soar and have wished, for a moment, that I possessed his wings.
+Few can comprehend time as I do – it is the very engine of the universe.’
+As it had been with Bjell, it was a bad way to die.
+Yesugei and the Khan left the chamber after that, escorting Horus back to his shuttlecraft from where he would go on to command the entire network of expeditionary fleets.
+In the week since Bucepholos’ failed coup, the renegade patricians had either surrendered or retreated into the hinterlands.
+By fortunate happenstance, Magnus and his Thousand Sons were traversing the outer edges of the system and offered their assistance.
+Many legionaries had died in the combat that followed, and the cadre of Stormseers under Borghal’s command had shrunk down to four.
+‘Then perhaps one of us might better lead this expedition?’ said Harkor.
+There were holes in the command structure, and the Phoenician was seeking to fill them as swiftly as possible.
+They had pummelled one another to the edge of consciousness, demolished half of the Tyrant’s palace in their fury, and still the Lord of Angels was demanding satisfaction.
+There are those on Terra who don’t see things our way.
+His enormous, dog-toothed shoulder rim was still higher than the regimental crest on Riordan’s cap.
+He assumed a more respectful expression, yet returned the look of the First Chaplain in acknowledgement of the moment and their achievement.
+The legion­aries of Terra are my sons as much as the legionaries of Nocturne.
+‘I had always believed…’ He knelt, holding Lorgar’s massive hand in his.
+Princeps of the Collegia Titanicus sometimes commanded their giant war-engines in a similar manner, and it was said the connection to the Omnissiah was sublime.
+He had not heard the voice that had spoken to Vaughn.
+Relaxed, seemingly entirely at ease with the world, Lorgar broke from his followers and advanced towards the storm.
+Orfeo had sent them directly into the heart of the Tyrant’s throne room, right at the topmost pinnacle of the Crimson Fortress.
+I authorised it because Hierax specifically referred to his Chapter Master.
+Fenc had a sense Corax found it hard to engage sympathetically with enemies who thought differently.
+I was moving before the ruined corpse of my Headhunter had hit the ground.
+From the centre of the shield wall, Mago drove his spear forward and back, forward and back, in union with his ­veteran front-rankers.
+Such was the monumental scale of man’s continually expanding dominion that such a length of time had passed before the Throneworld had taken notice.
+That had not kept him from persisting at it long after his stubbornness had driven half of the III Legion to despair.
+Qin Xa remained on the flagship, as was his duty, as did Yesugei after dividing the Legion’s zadyin arga between the various divisions.
+I was not immune to the excitement myself, even though I already knew what was being discussed.
+‘I know that, but if we are reckless we risk losing everything this ship may teach us of Morningstar’s past.’
+Working in silence, the servitors quickly sheared Iocare’s head to the scalp and marked points of incision across his skull, all under the careful supervision of the Librarian’s specialised kin.
+Chronologically, the boy was probably some years older than the Night Haunter, but he was young, very young.
+‘No, we cannot,’ snarled Russ, striding from the throne and beckoning his warriors to follow.
+‘Jusua and his brethren were the last of the Relic Wardens.
+You are aware of the new Order of Remembrancers that the Emperor has instituted?
+More so, perhaps, than any of the Lion’s brothers, for, whatever their view or wish on the matter, there was but one amongst them with claim to being His firstborn.
+As for myself, I’ll stay here and help you kill this bottle, if you like.
+‘I will do what I must, to see this thing done.
+He already knew what he would find as the Legion made its way deeper into the ruins.
+Kor Phaeron knew he would have to be careful, lest Lorgar started seeing the slaves as victims rather than deserving of their suffering.
+Ahriman and Phosis T’kar were the last to board and were standing on the embarkation ramp when Perturabo came over to speak to his brother.
+The cudgel of a Covenant mineguard hung at her hip, carried more as a trophy than a weapon.
+It seemed like a foolish question, but Atharva had no readily available answer.
+I looked over my shoulder towards the far end of the corridor, where a window looked out over Prime City.
+‘But I am not from Olympia, of that I am sure.’
+‘At least tell me something!’ said Elver with a courage that surprised him.
+From what I’ve been told, the majority of this planet’s population lives in poverty such that even the most wretched slum-dweller on Chemos – when there were slums on Chemos – would pity them.’
+I show the tech-guilds mercy, I will show you mercy also.
+Several main criteria dictated their selection – the procession of their orbits relative to the other Thousand Moons; the weight of fire their guns could bring to bear in combination with their neighbours on eight key quadrants; the strength of their defences – those of medium potency were selected first, being suitable demonstrations of the Raven Guard’s power without posing too large a danger to the forward insertion teams; the size of their populations; and, finally, the intransigence of their rulers.
+‘It is the name of this vessel,’ said Shai-Tan, running his fingers over the walls and leaving painfully bright trails carved in the metal.
+It wasn’t long before the inhabitants of Aphelion-2 became aware of the war erupting in their midst.
+‘The Legion has not the strength to fulfil the duties of every mortal officer on our ships,’ said Garradin.
+‘As the Angel noted in his reports, sire,’ said Duriel, walking out onto the ramp behind him.
+‘I am talking about being the first Legion to rebel against its patriarch.
+Most chose conversion, either out of fear or finally repenting before the sermon of the Ecclesiarch, having initially resisted out of fear of slavery.
+He moved to the window and opened it, in full knowledge that Lorgar’s hearing was uncannily good, like all of his senses and much else about him.
+Raptora energies warped the metal of the Hydra like softened wax.
+‘We must preach the Word of the One, and the Truth will return to Colchis.’
+At the final turn, another anonymous hooded warrior barred Aravain’s path.
+And to think that he had once thought Moses Trurakk a giant.
+‘Not quite as welcoming as your home world, lord,’ Azkaellon said.
+A nagging sense grew in me that there was something wrong with me, that I had been damaged in some way.
+With the Termite destroyed, the final stages of the campaign were heavily dependent on precise coordination and all the companies being in position at the critical juncture.
+A coal fire burned in an open brazier, chasing shadows across walls of dressed Calibanite stone, glinting off the ancient weaponry on display.
+‘The Varvans believed in a race of giants that would descend from the heavens and bring them into the light,’ said Agapito.
+Sixty thousand soldiers of the Imperial Army are a day’s warp travel behind me.
+The Emperor stood there before him, sublime, burning sword held out in challenge, and Ferrus knew.
+I had every confidence that my Legion would surpass the Lion’s expectations, and more than hold their own.
+The lengths He went to, and what He willed us to do for Him to achieve unification.
+The honeyed words of the Ghennans flickered through his memory, spoken in that bizarre, shared chorus.
+According to Dantioch, unlike the ones we faced here, those hrud he encountered fought only if confronted, at least until the last days when they appeared in greater numbers.
+They spoke to Angron’s mind in a chorus of their voices, with the warmth of new light spilling over the land at sunrise.
+Phoros, Iskia, Vren and Achos fell in quick succession on the first two days.
+I felt no guilt, merely gratitude, even though I quite possibly owed Gukul my life.
+‘Naturally, but then why make children, if you are not interested in learning from them?’ countered Guilliman.
+The Powers assert the Truth again, assuring us that we tread the path.
+‘At this moment, yes,’ said Skraivok, ‘but with them we shall reforge this Legion in a new image, a cadre of killers like no other before it, merciless, without conscience.
+‘The culture of the Twenty-second has a strong Terran influence, and that influence is itself shaped by the Destroyer companies.’
+Normally Mago would have forbidden such means, especially as the Legion was still on an active war footing, but in light of recent events he relented.
+‘You have all read the same reports as I have been granted.
+‘I prefer not to make assumptions,’ said Forrix, tired of his constant sniping.
+We will do whatever you ask of us – I swear that oath to you now and always.’
+My ship may still be out there, but we would need to get past the xenos in orbit to get to it, and the shuttle I have here would not survive such an attempt.’
+‘I’ve seen it before – secret societies were rife on Chemos in my youth.
+In contrast to the rest of the prow, which was crammed with lance batteries, torpedo tubes and all the many systems that made them function, the open space of the Mason’s Hall seemed an indulgence, but it too had a purpose.
+Even at first glance, Guilliman could easily imagine how this creation had come to pass.
+He opened his eyes, but saw only the darkness of the sunshade for a few heartbeats before the scarf-shrouded, weathered faces of the Declined intruded upon his view, concern in their dark eyes.
+Ani nodded and opened the door of their cupboard to wrap Seddy in her bedroll, then quietly shut the door again.
+‘I curse that I know not when the Lion truly died,’ he murmured.
+The Callax worker protests had shown him the consequences of disorder.
+Chapter Master Iasus and some elements of his force have survived.’
+‘Do you think,’ Agapito asked, as he poured out the contents of a small aluminium flask into two mugs, ‘that it is going to work?’
+‘If not in the grand library, he is among his people spreading the True Word.’
+There is no ban in the Legions on the use of these weapons.’
+We killed anyone He commanded, even those He used to lead.
+‘This is not about truth,’ Niasta said, just a trace of exasperation creeping into her polished voice.
+Perhaps the Lion had taken his Stormbirds to the Tyrant’s fortress, and he himself had teleported in.
+Like Abdemon, he was of the Two Hundred, and had been the only surviving member of the Legion’s apothecarion.
+Angron ceases to breathe, holding his breath as long as he can to save oxygen for Hexx.
+It must be founded upon humility if it is to be of worth to the Powers.
+To the wider Legion, the 18th Company was known as the Unbroken.
+‘If Balthius is overthrown, it is the culmination of corruption, not the cause.’
+‘Perhaps one day, far from now, you will encounter an enemy that you cannot best,’ the Tyrant said.
+He became the rallying point, the glorious hope of the burgeoning Imperium: apparently the first of the Emperor’s sons to be found, and destined to be the greatest and brightest of us all.
+Blood fountains up from a ruptured throat, spilling out over Ryn as he shivers in agonised convulsions.
+The old and the new, Rhy’tan thought, and wished the words did not trouble him.
+Tolly was a simple man, and could not comprehend another had almost taken the Emperor’s place not very long ago.
+I am a skilled fighter, and even Valdor did not outmatch me, although that contest was so brief that no particularly telling conclusions can be drawn from it.
+‘But there is a first time for everything, and I need all your warriors on board.
+Horus thought it too soon for Fulgrim to spread his wings and fly unaided.
+Sensible, given that he was the fastest of the Emperor’s sons, by all accounts.
+‘For one so gifted with words and speech, you lie terribly, Lorgar.
+Into him the Powers had invested knowledge of the Truth and the strength to be the Bearer of the Word – the seer among the blind, the listener in a crowd of the deaf, the speaker in a world of mutes.
+The statue was intact, though covered in a thick layer of dust, just as everything in the ruined Palace was.
+At first, Perturabo had taken their panic as the first signs of victory.
+Officers of the Iron Hands, he knew, were encouraged to settle such matters for themselves.
+‘If there is a threat, I would like to know about it.’
+Magnus let Shai-Tan’s words wash through him, their remembered pain breaking his heart.
+‘I am trying,’ said Tessza, data light swirling around her station.
+A heavy strike broke four of Karzen’s ribs and sent him back down.
+Do you think me so lacking in honour and fortitude that I would suggest a retreat lightly?’ said Zoltan forcefully.
+He tried to see the effect of his words on Gage.
+For Numeon, the second of Vulkan’s arrival seared itself forever into his consciousness.
+They had allowed him to achieve things all but unknown in the days before Prospero.
+‘Legiones Astartes,’ Norlev muttered, understanding now the uncertainty he had felt in the alien voice before.
+Looking back on it, Tensat thought his old man had enjoyed frightening him.
+Iron Warriors stamped out of the thinning smoke victoriously, but a dozen at least lay dead.
+It is said that he plans soon to retire from the forefront and better attend to the construction of his Imperium.’
+‘The losses we suffered there almost carved the heart out of the Legion.’
+The rain was coming down hard now, soaking Tensat’s disguise in metal-scented water.
+The jarl of Dekk-Tra had a face seemingly carved from wind-blasted bedrock, long and lean and riven with scars.
+In Quin’s opinion, there was little to mark the natives of Chemos out as suitable warriors.
+Magnus had not considered the idea of his act becoming widely known, but with troublesome rumours already circulating the crusading expeditionary fleets, perhaps a story to reinforce the positive aspects of the Thousand Sons’ abilities would be no bad thing.
+Ahriman reached deep inside himself and used his Pavoni arts to blunt Forrix’s pain.
+‘The Emperor desires Gardinaal to be taken intact,’ the warrior added unasked, filling the silence.
+Where were they when Angron had called, and none save Iocare had answered?
+The heat of a thousand confined bodies generated a steady wind that buffeted Caius as he approached the doorway.
+He’d often thought much the same about his time in the Palace on Terra.
+Even Chemos, an exhausted desert of hollowed mountains and drained seas, had possessed bright spots, oases where beauty lingered.
+‘Do you think I have time to speak with them all?
+As the Lord of Iron returned to his gunship, Ahriman saw a look of profound sadness in his primarch’s face.
+For all the battered dustiness of the crawlers, the Synans kept the machines on which their livelihoods depended in good condition.
+Their kind aspired to the flawless logic of machines, but they could never learn what the Lord of Iron had known instinctively since birth.
+The faintest hiss of air was the only warning Guilliman got of the attack.
+The fireball filled Vaughn’s vision, a misshapen, monstrous, grotesquery of a ship.
+Lorgar was about to speak but Kor Phaeron heard steps in the companionway and held up a hand to silence the acolyte.
+‘But nor can I simply leave the tens of thousands of people aboard the Lux Ferem and in Calaena to their doom.’
+The fourth – some sort of minor official, Elver thought – travelled alone.
+He had gone from a warrior of the Nan, to a warrior of the Khitan, to a warrior of the ordu of Jaghatai.
+And, more than that, Ahriman suspected he and Forrix were becoming friends, which had surprised him, until he thought of Magnus and Perturabo’s friendship.
+‘Lord Commander Cicerus reported a large air defence force of capable atmospheric fighters.’
+‘He has dwelt among us here at Lochos now for ten years, and although his birth date remains as mysterious to us as so much about him, we reckon it is now his sixteenth birthday, on this, the anniversary of his coming to us.
+In a few weeks, with barely a handful of warriors, I accomplished what would have taken my brothers months, and hundreds – if not thousands – of warriors.’
+For more than a year, they have been fighting the orks in the Taras Division.
+The Lion looked as if he was barely seeing the world around him.
+‘I say many of the other Legions see you as a coterie of sadists and murderers,’ said Corax.
+A kilt of leather hung to his knees, and a hook-bladed sword crafted from Prosperine silksteel was belted at his waist next to a colossal tome of psychic lore.
+‘The High Lords have decreed that the wanton exaggerations of the Imperial envoys are to be disbelieved by all citizens.
+‘We showed this place to you for a reason, Phoenician,’ the masked figure continued.
+The admiral imagined his opposite numbers on the Carinaean warships staring at similar displays and thinking similar thoughts.
+‘The question then is this – is Muspel itself infested with the santales parasite or have we stymied its encroachment here by denying it the planet’s ships?’
+‘These bastards will pay in blood for this, and I am going to enjoy every second of it.’
+‘How can we possibly navigate this?’ said Phosis T’kar, staring in wonderment at the smashed city.
+Gothic was the language of the Imperium, of course, but there were innumerable tongues individual to systems, planets or particular ethnic groups.
+Kor Phaeron could not look at Lorgar, wrathful and ashamed at the same time.
+Visibility was poor, and what Vaughn could see was the madness of war and volcanic mayhem so utter, coherence was lost.
+‘So we have a method of getting into orbit,’ I said.
+The differences between them were so great that Resalt thought them obscene.
+Though Iasus and Hierax might as well have been statues, Guilliman could still detect minor variations in their bearings.
+Then again, if Roboute had known of this event, and known it was me involved, perhaps he would have described it as fleeing after all.
+The blood had already ceased flowing by the time Mago finished.
+Vapour pillars of departing vessels columned the volatile sky and a nimbus of flickering energy hazed the air above the cliff-like dorsal surfaces of the Lux Ferem.
+Perhaps it was a little arrogant to think he deserved all of the credit, but he had guided Lorgar well and the primarch had recognised that, rewarded his contribution and loyalty.
+They had their own ciphers and code-speak, of course, but the Custodes were all creations of my father, as was I, and He had gifted me with an intellect somewhat in excess of theirs.
+‘We do not know that he is dead, Xarl,’ said another.
+So it was that the three passed out into the west, tracing the old pilgrimage paths towards the Ulaav, just as they had done before the Emperor had destroyed the past in order to create the future.
+He pointed to the ceremonial sceptre carried by the head of the Covenant: a golden, jewelled counterpart to the crude weapon he had fashioned for himself from a censer and axle.
+But if I believe the battle to be in any way jeopardised by your interests, I will kill you myself.’
+Despite what you say I am sure I can find warriors fit for the same role.’
+‘Several of those who spoke against you in the Consortium have left Vharadesh with their families and entourages.
+He knew Guilliman was not asking whether he had spotted the foe.
+He took a breath, realising that Perturabo had spoken to him.
+Another kind of night was gathering over all of Antaeum, a night that would not pass for centuries.
+He and I were so similar, we could have been twins.
+‘My lord, we are entering orbit over Twenty-Eight One,’ Abdemon said, his voice shrouded in static.
+It was no easy thing for a Space Marine to be in close proximity to their ­primarch.
+The Palace was a never-ending project, they said, a billion techwrights working on it daily to render the peaks into cathedrals of the mind and the soul, raising up monuments to Unity that would endure for eternity.
+The Sons of Shaitan showed no mercy, turning their weapons on the young and the old, the strong and the weak.
+This was not so very different in concept – although drastically so in scale – to what my father had done with my brothers and I. Faced with biological limitations, humanity had found a way to surpass them in order to achieve the results we desired.
+And respectfully, whatever rank long service has earned me, I’m a medicae.’
+‘If he feels anything for the fallen men, he hides it well,’ said Fortreidon.
+‘We take the governor and his family into protective custody…’ He paused.
+The main nave ran for a third of that length, and within the vast structure had been assembled the commanders and their staffs from every Chapter of the Legion.
+‘I would have expected that suggestion from Ferrus, or maybe even Horus, but never Russ.
+He rarely displayed any strong emotion, and so he betrayed no surprise at the discovery of the Ghennan’s inhuman nature.
+‘Angron has failed to drag Hexx from the shores of death.
+T’kell was laughing, and it took Rhy’tan a second to realise that he was too.
+Atharva was loath to leave Zharrukin, but to stay would be to risk the lives of the conservator’s staff of archaeotechs and all they had unearthed thus far.
+Fulgrim’s expression didn’t change, but Pyke could feel the sudden tension radiating from him.
+‘Kor Phaeron is archdeacon, but in your absence might as well be Ecclesiarch.
+‘We must forever desire the gaze of the Powers,’ he said, clearly, slowly so that the diction device could catch each word precisely.
+‘I mean no disrespect,’ said Sentril, ‘but you underestimate their pride.
+As far as the Lion was concerned this war had ended with the destruction of the khrave and the demise of their lord, but the fighting aboard some of those ships continued to be heavy.
+Somewhere in this city were two adults who had seen my true face, and knew I had an interest in Bar’Savor.
+‘However, for our efforts to create a working reproduction of the Nails, it is revolutionary.’
+‘So tell me,’ said Jorin, ‘ever fought beside the First Legion?’
+‘The days when I could count my rivals on one hand are gone forever.’
+They saw me coming, for I made no effort to hide.
+But by then, the Khan himself was almost invisible, hidden behind a curtain of severed flesh and thrown blood, a primordial force burning through the xenos ranks, inviolable and darkly magnificent.
+The rest of my time I devoted to learning, both about myself, and about the world my father and Malcador had created.
+For this, the boy thanked the Night Haunter, and he was loved for the change he brought.
+I Bear the Word as you did, and the converts grow in number, but this cannot be what the Powers desire of us.’
+‘And if the Emperor does not think as you believe He does?
+How dare their messengers be so calm, so assured, thought Perturabo.
+There were many who fought for Deliverance that were too old to be elevated to the Legion.
+It was not alone – Hasik’s vessel, the Tchin-Zar, came with it, as did half a dozen lesser craft.
+Corax sipped the wine while Guilliman took a moment to formulate his answer.
+As captain of a support vessel she was not privy to my true identity, but she was well aware that a lord of the XX Legion stood at her shoulder, and I had no doubt she wanted to impress.
+A chunk of basalt the size of a Rhino missed Numeon by inches.
+Little could be seen of Taranthis from the ground, for like the tezenite mine workings for which it was famed, the settlement was mostly dug beneath the hard sandstone and granite rock of the hinterlands known as the Copper Plate.
+At Nedella, the Synan brothers transferred their cargo to other, more local contractors.
+Now I will have to appoint new chief guardians of the armouries and museums.
+But sooner or later you will have to answer to Ferrus Manus.’
+In his mind’s eye, Perturabo saw what the planet would look like through the temporal wave: a moon’s reflection on a pool shattered into a thousand curved pieces by a cast stone.
+The Lion visibly started, an expression of incredulity spreading across his face.
+Kor Phaeron blink-activated an icon in his display to reply on the same frequency.
+To the converts this was not only a practical nightmare, but also an injunction against all they had been taught by Kor Phaeron.
+Such a weapon could not truly harm my father, but it would provide the wake-up call the Palace’s defenders so desperately needed.
+‘For those companies as they are presently constituted, I hope not.’
+Inardin’s paladins instantly fell into a defensive cordon around their lord, but the Lion gestured calmly for them to fall back.
+The Legion was pulling its full strength together, and over the years that strength had grown indeed.
+From Ferrus’ cage, Akurduana could see across the Practice Hall from end to end.
+For Fulgrim, whose perceptions were far beyond mortal, it was an eternity, in which to prepare for what came next.
+‘The Nails will not change any of those things,’ Mago conceded with a shallow nod.
+‘Hrastor came here himself, though he is well into his eighties and had vowed never to travel beyond the walls of Epherium again.
+‘The Nemesis Chapter stands ready to deploy when and as ordered,’ Hierax said.
+The answer had been in the manuals, as Fulgrim had expected.
+‘Is it normal for a Legion combat squad to be accompanied by one of its Librarians?’
+The psyker was howling in denial, crimson energies whining and sparking, flickering about Ferrus’ wrists as though he had plunged his hands into electrified blood.
+If you can restore communications with the rest of the Legion…’
+From these, Imperial commanders were quite clear that the Tyrant was not in the slightest part intimidated by them, and nor did he have any intention of running.
+Two Iron Warriors stood at the command table in the centre of the space, haptically shifting data manifests between glowing tags of starship designations.
+And has the Alpha Legion heard any word as to who this commander would be?’
+Outside the Stormbird, the air was growing dark as the gunship passed through the upper atmosphere.
+The Emperor of Mankind sent out His crusade to save humanity from creatures like you.
+‘What name will you choose, my son,’ prompted Dammekos, ‘to be remembered in the hallowed annals of our family?’
+The addition of the Invincible Reason and her fleet would allow them to project their will over countless more worlds.
+It is especially problematic among the Xeric tribesmen I inherited from father, though I have begun to notice it among my warriors from Deliverance also.
+An elaborate hierarchy of symbols identified him as a knight of the Third Order, 15th Company, commander of Tactical Squad ‘Martlet’.
+‘But I feel this working of iron is not my true strength.’
+You are, however, if I may beg your indulgence, new to the esoteric field of temporal engineering.
+Firstly, it tells us Rogal believed my Legion should work as directed by the Imperial Fists, and that my methods should be subservient to his.
+Heavily defended by six sets of walls each hundreds of metres high, the road made its unhurried way to the city gates of Kardis, seat of the Tyrant of Kardikora.
+‘He calls himself the Khan, though I’m not entirely convinced he understands what the word means.
+The Legion was intolerant of curiosity, but suspicion was healthy, and quietly encouraged at all levels.
+His hand was around Elver’s throat and one of his strange ­pistols under Elver’s jaw.
+They’d fought raiders in the western provinces, and mutants in the Glass Waste.
+He spied the chief of the Declined tribe close to his tent, conversing conspiratorially with his family.
+When the Wolves charged, their cries were most often a cacophony of raw emotion, designed to be overwhelming and disorientating in their sheer volume and energy, but this was different.
+Corax spoke over him to a man at his side who wore the uniform of the Imperial Iterator corps.
+Vorias wiped the blood from his eyes and knelt beside the young Lexicanum.
+His methods have their place, but I shall show you a different way.’
+‘And what of the others, on other ships?’ said Kuln angrily.
+The day would come, before too long, when the XX Legion would need to finally announce itself to the galaxy at large, even if I did not yet reveal myself.
+Their pilots were assigned other roles for the war games and so were left behind with the bulk of the Fifty-second.’
+At first, Elver took it to be a mountain, but it was far mightier than that.
+As fusils hummed into life and feyblades crackled, the old slave was certain that Ahengi and his companions would execute the son as they would the father.
+At times, Vulkan disappeared from Rhy’tan’s view, but he always reappeared moments later, hurling his attackers to the ground and gutting them with his blade.
+If not for them then I am sure I could hold their slave warriors at bay indefinitely.’
+The courtly, Calibanite manner of speaking whilst actually saying little was one that many of the older Terrans in the Legion found irritating.
+Hierax had been fighting in the XIII Legion for decades when the Emperor found his lost son.
+In particular, I find it annoying the way you present a confident face to the primarch and that of a worried grandmother to the rest of us.
+You can speak to me, just like it was in the past, for I do not forget.’
+In fact, the more I insisted that he did not speak with the ambassadors of Koray, the more he was determined to do so.’
+It was only through such a union that the achievement of his life’s work could be made possible: the fulfilment of his father’s mandate to forge a functioning, stable replica of the Butcher’s Nails.
+‘Malithos Kuln, you will find this warrior, and you will bring him to me,’ said Curze.
+He and Alkenex had been left behind to oversee the defence of Nova-Basilos.
+He was a cold man, aloof from the Dodekatheon and every other organisation.
+‘That is another thing I can neither touch nor see, another unverifiable object taken as an article of faith.
+‘Konrad Curze is not mad,’ said Sevatar with deadly, threat-filled certainty.
+Of the two dozen gladiators that had come from the caves to fight, only Angron and his mentor remain.
+He wondered again whether he was making the right decision in his support for the current occupant of the Gubernatorial Throne.
+Calaena’s buildings were older than any other Atharva had seen in his travels from Terra: glorious, domed basilicas, rotating towers of phototropic glass, grand libraries and bustling commercial districts that welcomed vessels from off-world and ocean-going haulers from all across Morningstar.
+The sidelined Fenc watched helplessly from the command deck of the Song-he, his fleet reduced to providing a protective umbrella to the Raven Guard ships against the weapons fire of other cities.
+He gestured to a heavily leaded window, beyond which spread the roofs and towers of the City of Grey Flowers.
+His wing-brother, Thyro, holding a glass and wearing a stretched grin.
+‘What Horus considers adequate, for instance, others might call grossly barbaric.’
+Perhaps, but He rarely spoke of the full extent of His reach.
+‘Anyone who takes the life of another Imperial citizen without recourse to the law is no longer loyal to the Emperor, no matter what they believe.
+‘I don’t know when I realised I was a monster,’ Curze whispered.
+He knew just how well defended the generator zones had been, and how hard Gahael must have fought to take them.
+I accept the nature of the Chapter’s feelings towards me, but I will have discipline.
+I have worked hard to distance my Legion from its past practices of terror.
+‘You cannot blame your losses on him,’ one of the Iron Hands growled.
+Harkor wore his helmet, but Golg was bareheaded, and the greedy sneer on his face disturbed Forrix.
+He saw that the guards and slaves had heard the clear declaration, not only reminding them of the Truth to which they were all subject, but also of Kor Phaeron’s authority over Lorgar and, by extension of that, every member of the caravan.
+He was a beacon of hope, both to the masses of Chemos and his remaining gene-sons.
+Always with regret, always with a tear and self-flagellation, but all the same Lorgar removed every obstacle between himself and his goal.
+He was the first of the captains to meet with Iasus.
+The captain of the 166th was younger than Hierax, and a native of Macragge.
+Our duty on Corcyra is complete, but our war is not.’
+The Lion had engaged at arm’s length, keeping his major warships out of the most concentrated areas of combat and firing from a distance.
+With its origins in the dark years of Old Earth, the Fusil Actinaeus’ destructive capabilities far exceeded the modern plasma weapons mass-produced by the forges of Mars.
+‘What is it?’ asked Atharva, as he and Ashkali picked a path through the rubble towards him.
+Spreading his hands along the flaking metal of the parapet, Dekka leaned over, as if it were the weight of his mind that pulled him forwards.
+The coming together of four full Legions was either the consequence of great events or the cause.
+As the Saviour in Shadow opened itself to the wider world, the hololiths took on finer definition and the figures they projected moved more smoothly.
+‘What you mean, and what occurs, are often two entirely different things,’ Telmar said.
+‘It looks like Morningstar is stripping them of their identity,’ said Ahriman.
+It is one I shall use again, should I have the opportunity to.
+We will take Thoas back, and we will build a new civilisation here.
+‘What does Kiavahr matter to you?’ he said, letting some of his bitterness out.
+Other ships joined them – the remainder of Bloodhowl’s battle-group, other warships of Tra – all under the suzerainty of the jarl Ogvai Ogvai Helmschrot.
+‘This is fine work, Master T’kell,’ Rhy’tan said as he drew near.
+However, he had been brought up as a knight, a noble protector of the populace of Caliban from the monsters that stalked its lands, and he was a hunter.
+They chafed under the rule of the Priests of Mars, and vented their frustrations against those still beneath them.
+They had stood by while one of their number had fired a grenade into an Imperial building containing Imperial citizens.
+The loss was a shame, but my Legion was still operating secretly, and we could not afford resentment risking that.
+‘Unless this clears up, we’ll have trouble restoring contact with the Imperium.’
+He would outpace them and his endurance is endless,’ said Nairo.
+In truth, Ev had been one of his cousin’s friends, not his.
+Hearing raised voices, Nairo was drawn to the bulkhead between the slaves’ quarters and the more spacious dorms of the converts.
+Until we can say unequivocally what the Powers wish us to know, what would you tell them?’
+‘Lord Arachmus, can you provide me with an estimate on timing?’
+Were Fenc to draw his sword, the scintillas from its gleaming blade would be sharper than its edge.
+The boy’s gut wound, framed by the lacquered purple and gold of Akurduana’s gauntlets, was a thin red line through tissue that was uncannily bloodless and clean.
+Amid the galaxy at large, he was feared or scorned, the leader of a Legion of barbarians and vandals, though few would have dared mouth such sentiments to his face.
+The mass insanity… It manifested through the psykers, infecting whole worlds and plunging them into an abyss of ruin and death.’
+‘It certainly does not require the official redeployment of Imperial forces to deal with it.
+The Klostzatz’s fate was sealed, and there was only one last thing it might do against the ork base.
+And the stakes I play for are greater than you can imagine.
+As I walked towards the Ultimate Wall, I left a trail of wonder­ment behind me.
+Once Corynth had put him on the right track, it had been easy to find the information he sought.
+Though the function of the machine needs no explanation, I did not tell you then of its provenance or of its history.
+‘In the Great Ocean, all things are possible,’ said Ahriman, holding out his hand.
+What was also undeniably true was that I could see lights approaching from the north.
+Phelinia Eftt waited for her next instruction in an isolated service stairwell.
+I did not see the sun until I was a man.
+It made the slave flinch when finally Lorgar laid a broad hand on his leg and spoke.
+Ferrus Manus took its haft in both hands and strode towards the buckled door.
+It appeared my first impression on Constantin Valdor had not been so positive.
+In a year of war, Vaughn had not yet been able to determine precisely how large the enemy’s force was.
+‘It is not in their nature to risk themselves,’ said Forrix.
+‘A child I was when we first met, but no more.
+‘You have been led to me, son, and I to you.
+The north and south were shielded by the embrace of the mountain chain, and to the west lay the ocean that surrounded Corcyra’s single inhabited land mass.
+Nobody had seen Lorgar for the previous day, and Axata had been tight-lipped about their holy master’s whereabouts and intentions.
+Across a lifetime that spanned more than a century, there existed three days that, to Iocare’s mind, were fundamental in the shaping of his destiny.
+The Anvilarium reminded Akurduana of the manufactories of the Urals, though even the X Legion’s colossal flagship, for all its youthful distemper, could not rival those cathedrals of industry for scale.
+The Mechanicum had to work for the advancement of the Imperium, after all.
+But I swear to you that even that will not suffice.’
+Beneath the hill of tanks, Vaughn saw motionless limbs protruding from the lava flow.
+‘It is claimed for the Imperium, for the Master of Mankind.’
+‘I come not as one who will bring you to the Truth, for it is already in you.
+Three standard Terran days went by without any sign of the primarch, and all attempts to contact him were unsuccessful.
+I wonder if Rogal would have made the same demands had he been joined in the field by Horus?
+The material was of a kind that magos explorators attached to the 2003rd had found all over Maripose and the Vaniskray: cold like metal, pliable like plastek, devoid of any colour or reflection as though it existed beneath even the narrowest wavelengths of light.
+Even though Lochos was a city of old men, the genetically unsuitable, children and women, the Iron Warriors treated them all with the same ruthlessness.
+It was worse in the ore-processing facilities, according to ­Alkenex’s report.
+Kor Phaeron paused a moment, to ensure he phrased his next words properly as he looked down at the child.
+The sudden stillness was shocking after such roiling chaos, and the Stormbird shuddered in release.
+What she’d singularly failed to appreciate was that Caliban, until about a hundred years ago, had been a pseudo-feudal death world.
+‘Arch-Comptroller Agarth has no such weapons, and if he did, why would he use them on his own people?’
+There were many things I had no experience of, and the abstract knowledge father engineered into me was no comparison to the thing itself.
+‘Your religion is offensive to me,’ said the Lord of Iron without preamble.
+The muted clicks of the Ravens’ voxes intruded on their frequency, a sure sign the Ravens were also communing with each another.
+‘I hope you know what you’re doing,’ Orontes voxed over a private link.
+The Khan endured it all for three days, locked within the assembly hall of his new palace, his brows knotted and his fingers drumming on his cloaked knee.
+I was not sure where I was, or how I had come to be there, but I knew my name.
+And so, in the darker hours, he ruminated on the Legion’s purpose in the Sak’trada Deeps.
+From now on, Nostramo will be ruled for the benefit of the families who made it what it is.
+Roboute raises an Imperium in miniature that celebrates his name and yours.
+So Yesugei had avoided them, both during the Triumph and also in the aftermath.
+‘Is it not the Olympian way to present the iron facade to hide the fractures within?
+‘But I’ll tell you what I told Jorin, though it did him no good.
+‘A good place as well to stage an emergency warp jump,’ said Perturabo.
+‘I thought that I could lead the Legions as well I lead my own.
+He did not haunt the dreams of men in the way of Fulgrim or Sanguinius or Horus, but he was beautiful, as a charnabal sabre or a hand-wrought suit of armour could be beautiful.
+His command would be a wind of change through the Chapter.
+The moment Vashti had been planning for the last six days had finally arrived.
+He had guessed, but Guilliman had made it clear his own counsel was enough on this matter.
+The Emperor’s gene forging was supreme, but the genetors of the Age of Technology were master artisans of death.
+When you next converse with your master, tell him that I regret we were not able to join forces as arranged.
+That was not what Ahriman meant, but he did not correct the Iron Warrior.
+There is much work to be done before Byzas can assume its proper place.’
+This makes Angron hesitate for a moment, and he doesn’t see the knife until it is buried to the hilt in his gut.
+‘A bit of theatre never hurts in these situations, I’ve learned.’
+‘So long as they do not resist too fiercely,’ Gukul muttered.
+Fabius said nothing, but from the look on his face, Fulgrim could tell that he didn’t think so.
+The Ravenlord’s sensitive olfactory sense registered the fermented juices of grapes wafting from its throat.
+These ones were too old to become his brothers, but their children, and their children’s children, might yet serve beside him in the vanguard of the Great Crusade.
+The Emperor speaks of enlightenment and the end to superstition, and He sets this coterie of priests over us.
+Shock marked the face of Gahlan Surlak as Angron emerged into the corridor.
+He could steal a few seconds from the march forwards to hear what the captain of the Destroyers had to say.
+He’d meant to ask Chancellor Corynth about it, but hadn’t as yet had the opportunity.
+So far as the vast majority knew – even those who had insight into the Astartes project – the XX Legion had not yet progressed to full uptake, let alone reached readiness to have a presence in the field.
+Imperial warships were designed to function as parts of a greater whole, particularly smaller escort vessels like the Edge.
+Much further out was a dispersed cluster of tags denoting the location of Corax’s fleet.
+‘I am aware of this – as aware of it, in fact, as you were aware that others have tested Perturabo’s strength in a similar way.’
+The Ultramarine blinked up at Ferrus’ throne, but appeared to have lost the power of speech.
+The ten captains of the Nemesis Chapter formed an honour line before the bay doors.
+‘Keep running,’ Duriel shouted to them as they approached, waving them on towards his forces still battling around the bridge-fort.
+Surlak took a step closer to Mago, their feathered breath mingling in the chill air.
+If we do not aid them, we will give the Sodality time to better coordinate their efforts at resistance, and the war here will drag on for months.
+His hope, in observing the war, was to find the opportunity to prove to Guilliman the need for the Destroyers.
+I cannot refuse Chondax, but someone must represent us at the conclave.
+I will destroy it so Kardis is aware of our intentions.’
+I shall alter the training regimen of the Forty-fifth Company to suit, don’t you worry.’
+The vehicle slowed, the drill turning fruitlessly in the air as T’kell struggled to reach the next wall.
+Never in Lochos’ history had so drastic an action been undertaken.
+If Bucepholos wasn’t involved, then this truly was a waste of time.
+He used the bandages to bind Lorgar’s arms, while around them the battle continued to rage.
+Scores of captains and Chaplains, the banners of their companies with them, watched from afar by the golden-armoured Custodians sent to enforce the will of the Emperor.
+Not once, in all his years at the Lord of Iron’s side, had he ever seen Perturabo express doubt.
+All the blood, the death, the torture… Those things I can understand, but one act I performed, though righteous, haunts me yet.
+Like the allied chieftains of a war council of ancient times, they assembled in an isolated corner of Mago’s ship, where the leader of the Unbroken waited with Astakos and Hanno at his side.
+So I – and, it must be said, Malcador – nudged the direction of events so my brothers would be discovered sooner, rather than later.
+‘How could those Sons of Shaitan fanatics build such a thing, let alone keep its construction secret from Imperial command?’
+Some other Legions might shun the use of psykana powers, but I saw no reason not to adopt them.
+But Hasik was right – the one in gold was just a little further along the arc towards perfection.
+The organisation of the evacuation was under the aegis of Konrad Vargha’s Gubernatorial Guard, but their breathtaking inefficiency had jammed every highway and transit route for tens of kilometres.
+I have not met him, though – I have no insight into his ways.’
+Admiral So-Lung Fenc faced the ornate doors of his flagship stateroom, his captains arrayed in full dress uniform at his side.
+Civilians slaughtered by the hundreds of thousands, simply because their masters refused to join this “Imperium” of yours.’
+‘The Navigators refer to it as the Sea of Souls,’ I put in, and my twin nodded.
+Then flood-lumens suddenly blazed into life, illuminating an arched nave, covered in the dragon emblems of the Tyrant, its walls as crimson as the outer scarps of the fortress.
+A wealth of scarce minerals was Perturabo’s from that moment, and he had such plans for them.
+On some level, Duriel must have intuited this, that the workings of such a weapon derive as much from the man as from the machine.
+It felt similar to how I’d felt my father’s voice when He’d found me, but Malcador did not speak aloud.
+The archdeacon could not be allowed to dictate the thoughts of Lorgar in this matter.
+We will destroy them there, and open the way for Banzor.’
+Without the minimal oversight of Overton’s crew, things were beginning to go wrong.
+‘As we transition from day to night, heat to chill, action to contemplation, I shall consult the oracles of the skies and seek the Truth.’
+The lesser Dulanian troops were not so fortunate, burned alive within their carapace suits, shrieking as the liquid fire pulled flesh from bone.
+A seventh, also a member of the Two Hundred, stood somewhat apart and behind the others, watching in silence.
+If there were true justice in the universe, they would fall back before the glory of the Imperium and be shamed into extinction.
+The Angel affected nonchalance then, for the first time, and not altogether convincingly.
+It is, in my estimation, one of the most perceptive depictions of war I have ever seen.
+The Gardinaal war machine would have been an incalculable asset to the Great Crusade.
+Kor Phaeron turned from the slaves having pronounced his judgement, focusing his scorn upon Lorgar.
+Now Iasus stood in the centre of the pyramid’s enormous ground-floor chamber, his armour drenched in ork blood.
+Before the moon Lycaeus had been opened up for exploitation, the planet had been picked clean of everything useful.
+Whoever I am, I was made for more than such a petty realm as Olympia.’
+Tethys does not know how much time has passed since Angron’s axe fell.
+The routes to the Imperial Palace grow fewer and fewer the closer you get, so – having memorised them – it was easy for me to work out which road we had taken.
+‘We shall see how much blood your father is willing to expend in taking our homes from us,’ said Agarth.
+‘I never met a wall I couldn’t tear down,’ Helmschrot muttered.
+Half-supported, the catwalk sagged under the combined weight of Corax and his attackers.
+We left Captain Lanesra with instructions to proceed as usual with their cargo, but to be ready to return us to the Argolisa as required.
+‘We have decided we will not strike one who has been chosen by the Powers.
+A Space Marine couldn’t be seen to disrespect his primarch, even in jest.
+The Dulanian vessel spun away to port, jetting plasma, but Othgar kept in close, piling on the power to shut down the remaining distance between them.
+The Night Haunter’s differences to the human creatures he dwelled among were manifold, and not limited to his rapid regenerative powers, but they were among the most remarkable of his abilities.
+The Lion drank in every detail, memorising every star cluster and visual anomaly.
+‘What can we tell Malcador that he does not already know?
+‘If your victory here was hastened, it could re-establish your pre-eminence amongst the Emperor’s sons.
+Moments later, the deep rumble of an entire cliff face collapsing rolled back to Cassian.
+‘The expeditionary fleet is struggling to contain the united forces of the Sodality.
+‘The Carinaeans have the advantage of knowing each other well,’ said Corax.
+Five legionaries hurtling towards a vortex of destruction, and Numeon’s grin was back.
+The landing bays of the Klostzatz opened to receive the gunships.
+‘This sector of the Ultima Segmentum is riddled with the remnants of failed human civilisations.
+‘He will change you, though,’ he called out, and his accented voice sounded strange on the skirling Terran wind.
+Only the dark red walls of the township were visible – though the stream of heavy wagons that moved along the road between the mine and Vharadesh some one hundred and forty kilometres away betrayed its presence long before the defences came into view.
+‘Because my Father could trust us to perform the task as it needed to be done.
+‘No, I am one of the few remaining Iron Warriors to have been born on Terra,’ said Forrix.
+‘It is possible that the Imperium of my father will one day falter as you insist it must,’ said the Lion.
+The Librarian looked slowly down, as if his gaze were a precious implement with the power to drill unhindered through cloth, flesh and bone.
+And though you will never experience it, the Legion, all of our brothers, will.’
+For him, Fenris was the only world worth the name, and the galaxy too small to contain its magnificence.
+‘My counsellor told me you wished to speak to me,’ the Khan said, standing before Malcador and folding his arms.
+They inflicted almost as much damage as the Land Raider guns.
+‘It was a great honour you bestowed,’ said Ferrus, ‘allowing DuCaine to speak for Akurduana.’
+‘Then never ask me questions like that again, Sev,’ said Curze.
+‘You really believe there is some ancient knowledge buried in Zharrukin that will explain why Morningstar survived Old Night unscathed?’
+I am Fulgrim, and I come bearing tidings of peace and prosperity.’
+Hasik, Giyahun – you will come with me and the Legion keshig.
+Even poor Pandion, so frightened for his future, seeks to do what is best for Byzas.’
+Though Nairo was no expert in war he had seen enough of Axata and his ilk to recognise that Lorgar fought without training or thought.
+Thank you, Malcador, for teaching me how to hold multiple thoughts in my head at once, so I could present whichever I chose to the outside world, and bury the others within.
+It is no small endeavour – close to five per cent of the entire output of Sacred Mars may be consumed by the creation of a Gloriana war vessel for the duration of its construction.’
+He gestured towards Magos Bernt, whose defining feature was a mass of writhing mechadendrites lashing about over his stooped back.
+The V Legion delegation was small: Yesugei himself, four warriors of the ordu, a menial staff of thirty, some servitors and the crew of the starship Naman.
+‘In response to the Gardinaal’s offensive, you led a combined force of Ultramarines, Thousand Sons and a demi-legio of the Legio Atarus to drive them back to their walls.’
+And after I have wiped your blood from my hands, I will bend all my efforts to tearing this city down, stone by stone, until nothing remains and all its people are gone into slavery.’
+The Ecclesiarch had proven himself more than capable and now as archdeacon, Kor Phaeron ruled a world.
+At the fall, as Lorgar had promised, the Epiceans were given the choice of submission or death.
+‘Why do you laugh?’ slurred the Lion, staggering towards him, his fists still balled.
+When the Lion calls on me again, I will join you in this battle.’
+His father had taken a seat by the great celestial occullum and the impossibly complex maps detailing His plans for galactic conquest.
+It was a delicate moment and Kor Phaeron judged that Lorgar did not need instruction as much as guidance, to be returned to the path he sought.
+‘Did you know, he learned the entirety of Hrastor of Epherium’s Dialectica by heart in a week, all fifty volumes?
+‘Good,’ said Kor Phaeron, feeling a stab of pride at the boy’s forthright pronouncement.
+The hall of the tyrant was very different to that of Lochos in appearance, its architectural flourishes determined by the local geology and the quirks of the Kardikron national character.
+They have the same stiff neck, but they know how to run a Legion.’
+‘The primarch has ordered it, so let it be done,’ said Zhalsk.
+We had been on an intelligence-gathering mission into an Imperial city; there had been no need to complicate matters by bringing weapons, or so I had believed.
+On Vaughn’s instructions, the command module of the Cauldron had been made his permanent residence.
+‘No, we do not do that, for we do not answer to the Covenant but to the Powers.
+‘By the oaths you have sworn to me and to this order I have drawn you from your duties to the Legion.
+Even though he would not know what we had attempted, I could at least try to reach him.
+‘I hear some of the Emperor’s cattle are worshipping my father as a god,’ said a hissing, growling voice behind the throne.
+Ahead of them, in the void beyond, the sleek grey profile of a VI Legion destroyer slid across the abyss.
+Not in any objective sense, for Perturabo was superior to all men, but Andos was balanced in a way that he could never be.
+Either my father did not know of it, or He thought it unnecessary.
+The admirals were refusing to lend their lances to the surface fight and run the risk of killing their Legion Masters in the crossfire again.
+I freely admit that I am not immune to such things, for you see… I know fear as well.’
+Heartened by these words, he left Kor Phaeron, who was also invigorated by the exchange.
+People saw Perturabo’s physicality and prodigious intellect as his chief strengths.
+As you see, I am an old man, and time is pressing.’
+‘They’re mobile and fluid, it’s not like we’ll be trying to mimic the Iron Warriors.’
+Many of the assembled wise men glanced at him distractedly, then turned their attention back to Perturabo’s drawing.
+Why didn’t you explain that I was doing what I was supposed to do?
+‘The tidings reach me now, but I do not believe them.
+‘Does it rankle,’ I replied, ‘to see your brothers from other Legions amassing victories, and being hailed as heroes?’
+Korit’s hand grew still as each of the connectors arrived at its destination, fully embedded within Iocare’s brain.
+Since the day of the War Hounds’ founding, whether the foe before them was xenos, machine, or even the Emperor’s own Thunder Warriors, the XII commenced hostilities according to their own fashion.
+The knight of the Ironwing had been outfitted with a psychically baffled helmet of the ­Santales order, and was flanked by a pair of towering six-limbed cyber automata.
+I have seen it with my own eyes and I have heard it from Gahlan’s own lips,’ said Mago.
+His visit to Bucepholos and the reports on the other members of the patricians had convinced him that the only way forward was to simplify things.
+Such a declaration was unheard of – it went against the very founding of the Covenant and the beliefs of Kor Phaeron.
+In practice, Pandion was forced to lean to the side and squint to see anything.
+Listening to the exchange, Adophus leaned in to Dammekos and softly whispered, ‘How old did you say he was?’
+The losses across the companies were high, and these legionaries hardly looked on him as a brother, even those who had been born on Macragge.
+He found his thoughts being steered towards his last memories of his brother, Horus.
+Behind her was a warren of poky offices where hundreds of Terran bureaucrats worked, monitoring Kiavahr and Deliverance for the Imperium.
+A grainy image of Polar-3 flickered on over the dull, black surface.
+‘I shall do as you ask, and the outcome of the mission will forever be at the forefront of my mind while I work, but I must insist that my collection of examples be allowed.’
+The Palace kitchens had endeavoured to produce something approximating Chogorian food, but it wasn’t easy to match the remorseless diet of flesh and fermented dairy products that fuelled the warrior clans of the Altak.
+‘Named for the santales, a plant native to the forests of Caliban.
+For all his might and intellect, Perturabo behaved with the same casual disdain for his elders that all young men had.
+The doors opened onto the finely appointed corridors of the Melanchromatic Palace.
+Lightning flares of pain exploded down the entire length of his left flank, but he kept his focus and fired a quick shot with Anvil’s Light.
+What remained of Giyahun’s body was consumed in that hurricane, burned away, rendered down to atoms.
+I will tell you now, because it is important to mark that we begin a new chapter in the Legion’s history but not a new book.
+‘My lord?’ said a voice, and Magnus looked up to see Ahzek Ahriman staring at him.
+‘I am not sure of what the Powers intend,’ confessed Lorgar.
+The texts tell us that one will come, raised above the others in the eyes of the Powers, to bring sight to the blind, hearing to the deaf, the Word to the mute.’
+The whine of a fusil shot broke the scene, hitting Lorgar in the shoulder.
+Cicerus angled his spear towards the two Iron Hands, his sword to Akurduana.
+His heart still thumped and the surrounding tissue was wet with life, thanks to Fabius’ skill.
+The Lion had brought the greater numbers with him – the Second, Sixth and Ninth Orders of his Legion – and outnumbered the Wolves by roughly a third.
+Blind, that man would nevertheless have sensed Curze as a darkness in the dark.
+‘What I am asking you to face is no different, in essence, from what I demanded today of Iasus and the Twenty-second.
+‘This is why I appreciate your company, brother,’ Ferrus whispered in Fulgrim’s ear, eyeing the statuesque form of Roboute Guilliman at the far side of the dais.
+Did you think Olympia is special somehow because I was found here?
+He did not protest, and that was all Guilliman asked of him.
+‘The culture of the Ultramarines must be as much a living thing as the Imperium,’ Guilliman said.
+Personally he felt he did not deserve to suffer for his ancestors’ wrongs, but that was what the Lycaeans had endured before the coming of the primarch.
+He had returned as quickly as he could, hoping to reach Nova-Basilos before the worst happened.
+Word around the palace was that his replacement, a keen young officer named Fayle, was impatiently waiting for Frazer to hurry up and retire, or die.
+This far west of the cordillera, Thoas was dark with eternal night, cold with eternal winter.
+The depleted armies of Olympia tried everything against their estranged sons, from outright assault to full surrender.
+Alkenex would kill them too quickly, and Quin didn’t understand the meaning of the word.
+The Mechanicum representatives he’d allowed to accompany him had already written extensive reports on the pseudo-archaic nature of the weaponry on display, as well as their effects on the surrounding landscape.
+He was not using an auspex, but I did not doubt him.
+Curze ­giggled, and Elver thought it the most abhorrent noise he had ever heard.
+The last man was taking careful aim at Pyke and the governor.
+Covering his eyes with his hand, Ferrus dug fingers into his temples and growled.
+The sound of a foot upon the steps drew Nairo’s eye back to the open grate.
+Still, she had been inordinately lucky: only she and Tessza Rom had made it out alive.
+The corridor was long, but not so long that Curze’s preternatural senses could not hear everything that occurred within.
+When Captain Thesuger’s fleet arrived to collect the recruits, there was no central authority to communicate with, and our demands for supplies were denied.
+They watched, surrounded by their staff, as Perturabo’s tanks growled their way towards the first wall.
+I wonder how much it is the result of my Father’s design, or if it surprised Him too.
+‘This is rather the opposite of that for which I am best known.’
+The official from the Palace, now revealed as Ert Ech Slavomar, Major-General of the First Division, Corps Logisticae, was clearly proud of what had been accomplished.
+I see the gunships and shuttles ferrying more troops and equipment from the fleet to Lament.’
+Secondly, it tells us that Rogal was aware of the potential for forcing compliance by means of non-military intervention as well as his own successes in the field, but had made no efforts to bring this about himself.
+Terran scribes and techwrights were imported, as well as specialists from a hundred other worlds, all of them made to swear oaths of allegiance to the Khagan and put to work turning the bastion, by then named Quan Zhou, into one of the mightiest citadels in the growing Imperium.
+The long-limbed equoids were only distantly reminiscent of Terran equines, being more related to ungulates.
+For much of the Imperial force, that is indeed what happened.
+With the instinct of a hunter, the Lion pointed down the corridor.
+He spent much time with Lorgar, reading from the texts and instilling his own thoughts into the boy.
+In time, either or both of them might well have ventured further than they already had, perhaps creating little Imperiums of their own.
+The squalor Corax had witnessed elsewhere seemed a thousand light years away.
+If we had been like our father, there is no doubt in my mind that the Legion would have achieved victory.
+Months stretched ahead, months of waiting for Curze to strike, or to come speak with him; equally terrifying experiences.
+It makes you look like a peasant, Griffayn of the Firewing had once said.
+Or was this merely an echo of the vision he had seen of the monstrous destiny ahead of Forrix?
+For now, though, the bulk of Hasik’s army made its way north in a long-strung cavalcade of transports and grav-lifters.
+The Eye of Horus, etched in platinum into the cheek guard of his tall helm, glinted from under the crook of his arm.
+He tries to turn and flee, but I seize his head and break his neck with a twist of my wrist.
+There was only one route to Gahevarla and it lay directly though the Scourstorm.
+A Terran would have been hesitant about describing such experiences as dreams.
+‘What can you tell me about Patrician Bucepholos?’ he asked, when Corynth had rejoined him.
+On every one of the artificial worlds, the Ravenlord’s visage was broadcast in massive form, and his black eyes looked deep into the beings of a thousand recalcitrant lords.
+What he did was terrible, worse than what I see in the visions.
+The orbit of Colchis around its star takes nearly five years – four point eight to be more precise.
+He did not begrudge them their chance to see Him and take comfort from His presence, for He understood the power of symbolism – He would hardly have armoured Himself and His Custodians in gold, otherwise – even while He strove to ensure that He was never misrepresented as a deity.
+‘Look, forgive my suspicion, this just isn’t the sort of thing the Legion gets involved with.
+But do not be seduced by the scale of His power – He has sacrificed more than any of us, and He does not use it for Himself.
+‘No,’ said Vulkan, his voice reverberating above the diminished clamour of the battle.
+The bitter irony was that Phalaris had not been killed in the field.
+‘We came here to forge a beginning,’ Rhy’tan declared, ‘and we shall!’
+However, my agents’ greatest successes came where I was in the theatre of war myself, and could utilise their placement to the greatest effect.
+– Eighth Captain Khârn, from his unpublished treatise The Eighteen Legions
+The greatest warrior of a Legion cannot shoot if his bolter is without ammunition.
+Now Gukul and his wounds were no longer clogging my senses, I could smell the faintest hint of Ani’s blood.
+‘I know you’re in there – I can see your carapace lights from here.’
+‘There will be twenty Legions – one in each of your images.
+The Covenant would bury our world with ceremony and holy cant, but we will die of it as a man in the desert dies of lack of water, for there is no faith in blind devotion, no Truth in the word spoken out of thought.
+For a time, the sky over the fortress had remained clear and still, even as Calaena burned and localised magna-tempests sent lightning ripping along its streets.
+This is not the wisdom I would have expected from the great Dammekos.
+‘Bitter experience has taught my Legion to bear moments like this.
+Your past as a teacher, the things you taught me… I think I understand now what Kor Phaeron meant when he punished me for learning the words but not the meanings.
+‘The future of the Legion stands upon a precipice,’ said Mago.
+The force of the blast knocked Rhy’tan down, and his armour sealed itself tightly against the first heat of the explosions.
+‘Which is, I gather, exactly what the Khan told the Emperor.
+We are puppets of time, you and I. For the moment you live.’
+This kind of void assault war is unsuited to your troops, as I am sure you realise, else you would already be masters of this place.’
+Why stage the attack on the convoy, and ‘Uzra’s’ subsequent death?
+‘I can’t decide if I’m that memorable or you’re that obsequious.’
+The temporal wave continued onwards through the Space Marine fleet, crippling ships and ageing crews to dust in seconds.
+However, the one thing my father could not bring wholly under His dominion was time.
+‘They are political creatures here – their first captain, Raldoron, spoke to me often.
+Looking up through his canopy screen, he saw the colossal black delta-wing shape of the Skylance gunship Oden Spear swoop towards the planet.
+More, I have proven my ability to any who might doubt it.’
+It was immense, titanic, a tidal wave of mindless force that dwarfed anything the Stormseers could summon or contest.
+We tell you of Old Night and you barely believe us, but that is not how most places were.
+At the end of them were the Gates, crowned with stone and barred with weather-blackened iron.
+The vastness of the Fist of Iron owned the void behind him, filling in for the occluded stars with a constellation of guidelights, communications lasers and coherence fields.
+It has been widely recorded, both in the recounting of remembrancers during the Great Crusade and within each Legion’s own archival histories, how Space Marines made battle.
+He had no time for Orontes’ rage, or to ponder their father’s.
+Your vision is too narrow to see the breadth of what the Emperor wants to achieve.’
+‘I wonder sometimes what you would do if I asked you to follow a course of action you regarded as unjust.’
+Hierax could imagine the situation must have been extreme to push Sirras to make that mistake, but it could not have been the result of applied reason.
+‘Your defiance will be noted in the history books,’ said Corax.
+Orasus was the eldest of the four, cut from the same rough material as Numeon.
+The Angel is eager to meet you, having heard so much of your accomplishments from a distance.’
+The Children of Deliverance provided everything she needed to do so.
+‘By then, the Phoenician will have come up with a suitable plan of action.’
+He wished the captain to know, also, that the contribution of his Chapter had value.
+Two World Eaters were in the pit, their bare flesh bleeding and sheened with sweat.
+The Haukr did not have the guns to penetrate the Faash ship’s shields.
+‘Do you know the legend of how I got these hands?’
+Have them bring the Emperor’s judgement on those who show the merest sign of disobedience.
+The lines of grief and despair, etched into the faces of the Two Hundred.
+I have already run simulations of action against a better disposed Sodality.
+Massed columns of tanks and mechanised infantry rolled across the Nigris Bridge.
+Then the Wolf King was gone, leaving the cathedral to the corpses.
+‘I am Baron Selus Hohngerron Marsepian, lord-general in perpetuity of the Forty-Seventh Lotharingian Grenadiers, and governor-marshal of Muspel.
+His followers looked to him, ready and willing to do his bidding, eyes bright and hungry for his Lore and his Law.
+‘What I do not know is when we will have it.’
+There was a reason the Emperor had all but banned such weapons.
+I could have engaged in a more direct manner of war, and taken the fight directly to whatever enemy my Legion and I faced.
+‘You remember Dulan, then,’ he said, and his voice was as bitter as gall.
+Evacuation crews debarked the refugees from the Lux Ferem as swiftly as possible, leading thousands of weeping civilians back to the camps beyond the city walls.
+‘I was telling you how I came to be here, on Tsagualsa.
+In that, only you can be the arbiter of the Truth.’
+A few Wolves lay among the heaps of the slain, but the vast majority of the dead were Dulanian.
+Justice will prevail, but at this time, vengeance would not suit here,’ said Corax.
+‘It’s a mystery to me how they get anything done,’ Abdemon said from behind Fulgrim.
+If he admitted the truth of what Iasus said, then he needed to think carefully about the deeper implications of what Guilliman had chosen to do with the Nemesis Chapter.
+As Castora continued her speech, lauding the benefits of the Truth and the righteousness of the Bearer of the Word, the master emerged.
+‘I am a Librarian of the Firewing, and a knight of the Order of Santales.
+The orks were going to have to cut through their dead to reach the Space Marines.
+‘This is what we have died for,’ he said to Numeon.
+It closed with the Ultramarines, its thousands of voices united in a single, shattering roar.
+‘We have the onslaught on the bridge checked for now, brothers, and for the most part our defences are holding,’ said Duriel, breathlessly.
+They arrived over the next weeks in their hundreds of thousands, and the people of Calaena opened their doors to every one.
+While you’ve been enjoying the comforts of Doctor Jaskolic, I’ve been up half the night filling out your invalid papers.’
+‘I will be there to see it unveiled,’ promised Magnus, and his enthusiasm for his brother’s works was genuine and contagious.
+‘I have ruled among the High Lords for over thirty-six hundred years.’
+It makes it hard to get an accurate picture of exactly what’s going on down–’ She paused, and when she spoke again her voice held a tremor of excitement.
+Over the command channel he voxed, ‘Gunships and artillery, you have your data.
+The sword chopped through the wood, and Perturabo cast it away.
+The perception of the orks as a single, solid mass dissolved as Guilliman drew closer.
+‘But then I myself saw something else, and it stayed with me for a long time.
+In moments, the entire fleet was consumed in a firestorm, and Fulgrim turned his attention back to the matter of his descent.
+His scrying powers were weak in comparison to his new-found potency in biomancy, but Hathor Maat needed no seersight to know that the volcano would soon obliterate every living thing within hundreds of kilometres.
+He was aware of Akurduana’s reputation, but this contest was skewed against him.
+After three hours and sixteen minutes of relentless bombardment, as the Imperial onslaught drove the numerically superior Gardinaal force from their perimeter defences, there was barely a wall left.
+‘This is a poor spectacle of victory,’ Vaughn admitted to Numeon.
+We shall be that change, Axata, you and I and the others of the true passion.
+It was as though a geoformer with primitive materials and grand visions had constructed a divine sphere, set it in the orbit of a star at the edge of Imperial space and named it Gardinaal Prime.
+Eiryk was on his left, his face flushed, Valgarn on his right.
+It had become necessary to physically destroy virtually everything the Wolves came across lest it revive, which had a punishing effect on ammunition levels and survival rates, and deprived the strategos of much-needed intelligence.
+While Cyrius was not his tutor’s equal, he fancied that he was the greatest swordsman on this planet, barring the Phoenician himself.
+‘Why are the worst villains always the most talkative?’ said Gun, loosing off a four burst shot from his weaponry.
+‘I had a little difficulty getting through the cordon,’ Tensat grumbled.
+‘There can be no heresy where the truth is concerned,’ said Perturabo.
+That Phosis T’kar was right made him only more reluctant to admit to his ignorance.
+Each and every one of us, Hanno, you and even I myself, we are like an incomplete puzzle.
+Ahriman nodded, already well aware that Forrix was something supremely dangerous, even if he could not yet understand how.
+His lord’s refusal to answer was an answer in itself, and truer in what it said than that which the Ironbringer sought.
+There are reports of ongoing fighting throughout the rest of the Sheitansvar.’
+But compared to the firepower of a combat squad of Dark Angels, the contribution of a few armed serfs was insignificant at best.
+Just as importantly, he knew he could trust Rhy’tan to speak with him honestly.
+‘Go on then, Perturabo, my boy, show our guest your work – don’t keep him waiting,’ said Dammekos.
+The sky was green, more green than anything Haldor had ever seen on Fenris.
+Everyone knew the Custodes were in command of the Imperial Palace’s security.
+And then the Night Haunter gave a low moan, staggered upright, tottered a few feet and collapsed in a drift of ragged black cloth.
+They would think they knew how the intruder was garbed, and I could easily change that fact.
+The weapon is light in Angron’s hands, like it was always meant to be there.
+Tethys sees the arena, the hot dust, once more through Angron’s eyes.
+The gate was almost a metre thick, and made in one piece in the mills of the Kontoros.
+The dust of it sticks in my throat, and I am glad that our battles here are over.’
+Within twenty seconds, Aphelion-2 was in the hands of the Imperium.
+Also, I was reluctant to let my Legion’s very first interaction with another be handled by someone else: not because I did not trust the ability of my subordinates, but simply because I wanted that opportunity to be mine.
+Cold, dark dread rose through the choked channels of Sevatar’s mind at those words.
+Magnus cried out as Ahriman was tossed through the air to land limply across one of the slabs.
+It was hard to converse in Gothic all the time, to recall the endless tide of details and absorb what they meant.
+‘Kept in bondage to the Covenant, I might have lived out my days on one of these plantations.’
+The deeper into the ship they went, the more it reeked of abandonment, and the more wary Magnus became.
+Turning the rope was one of the only traditions that Angron had allowed the Legion to adopt from his home world.
+‘I swear it, on my honour, as commander of the 28th Expedition, and son of the Emperor, I will save Byzas from itself.’
+Only when the last cannon had fired and the last piece of burning wreckage had twisted towards re-entry did the respective Legion fleets take up their orbital vantages again, each pulling back together into overwatch formation and facing one another across a wide expanse of debris-littered space.
+He was garbed in a mass-printed green jacket and trousers, exactly the same as a billion others like him from Central Processing.
+Though my knowledge of the Theologitek’s secrets is but a fraction of Master Duriel’s.’
+I enjoyed what I could do with it, for you, for the ordu.
+She and her wife were now serfs of the Legion, and their daughter would grow up to be the same.
+A smaller troop of Imperials marched towards them, down the corridor made by the two blocs of warriors.
+The image looked impressive if impractical, but Dammekos suspected Perturabo could make it work.
+As he climbed, Fulgrim calculated probable speeds and angles of ascent.
+My sources say that Bucepholos and his allies are acting out of desperation.
+‘Your sacrifices to save the people of the Taras Division will be remembered forever.
+The edges of the memory blur, distorted to Tethys’ sight by his father’s pain.
+I did not even have to explain twice the methods I had learned to hide my thoughts.
+The tanks held back, and Guilliman charged forwards with the legionaries of the First Chapter.
+‘I don’t remember the last time I had a meal I had to cut up!
+He knew this was his father and the father of every battle-brother of the XVIII Legion.
+Again, the commands were relayed by the powerful voices of the Therion sergeants.
+‘You believe you were made by those monsters?’ said Dammekos in shock.
+‘You must accept my apologies,’ the Angel said, gesturing towards two immense thrones carved from mahogany and capped with ivory.
+‘We’ve analysed the sonic aegis generated by the xenos,’ Jereth said.
+In the oculus, Resalt saw the distant blooms of cannon and ­torpedo impacts on the surface of the attack moon.
+For their counterparts within the knighthood of Caliban it was the maze that dominated.
+‘Rumours of him came to Lochos two years ago,’ replied Dammekos as Perturabo carried on speaking.
+My sons are dying and I am helpless to save them!’
+‘We will succeed,’ said Venn, with the supreme confidence of a child.
+Every node of the Imperium’s stellar communications network serving in the choirs throughout the armada had experienced the same rapid vision.
+The Angel placed his hands together, and his wings rustled softly.
+Every other Olympian youth looked forward to his naming day with great anticipation.
+Axata and Nairo came to a quick arrangement that the guards would not administer any punishments whilst the slaves would make no attempt to harm either the converts or Kor Phaeron.
+With a heavy heart, Perturabo knew only one logical course of action was open to him.
+The Khan raised an eyebrow, turning to Yesugei, who stood beside the command throne.
+This much, Guilliman could see or extrapolate from the wall of flames rising in the near distance.
+But that was to mistake circumspection for obduracy, aloofness for indifference, and Lion El’Jonson displayed neither.
+My Father showed me one of the fragments of his works that have survived.
+There were any number of secrets down there, and any amount of damage an intruder could be doing, certainly one capable of killing a Custodian.
+Gendor Skraivok found the racket profoundly irritating, but was bareheaded nonetheless, standing in the shadows for there was nowhere else to stand.
+It was no easy task: even for the vigilant machine-spirits within our Mark IV plate, there were a plethora of potential danger points to be aware of in this ruined landscape.
+That, somewhat counter-intuitively, suggested that even though these containers might be destined for sensitive areas of the Imperial Palace, the contents would be inspected by fewer people, which made them a better candidate in which to stow away.
+The very fact that the Emperor had not predisposed him with the ability was all the reason Akurduana needed to pursue it.
+My lord thought the old Legion relied over much on terror and slaughter to ensure compliance.
+A worthy death, although a futile one: a craft the size of the Vengeful Spirit has many sensor towers, and built-in redundancy.
+If you did, you are a far worse monster than I.’
+Each of its individual cobbles was patterned with a celestial arrangement visible from one of Morningstar’s many observatories.
+I especially suspected that he would not react well to discovering there was a battle-strength Legion of which he’d known nothing.
+Though dismayed by the thought of subterfuge, Lorgar seemed wary enough of his beatings that he held his tongue and shared his linguistic skills only with the slaves.
+The Lion rose to his feet without speaking, returning his sword to guard.
+I was intrigued as to what my intended destiny had been, but I kept my silence.
+Unlike Guilliman, he was unarmoured, clad in charcoal-black from head to toe, his face smeared with the ashes of his empire.
+‘But anyone who fought at my side during the deliverance of Lycaeus should be able to speak with me.
+‘I do not care who rules Byzas, only that their rule is a stable one.
+The Unbroken continued their march, as the Ghennan multitudes walked into range of their spears and the killing began.
+‘That they thought they could get away with it is an insult to the ­honour of the Third.’
+Without me, every mother on this planet would still be praying that the Black Judges choose not to visit during her children’s lifetimes.
+He shot a glance at Gahlan, but gleaned nothing from the Apothecary’s neutral expression.
+I want a workable plan to avoid a repetition of this debacle before I return.
+If Corvus’ plan works, it offers the best outcome for the rapid integration of this system into the Imperium, with the lowest casualties and the least damage to its material structure.’
+There is no more despicable thing than a traitor to the Powers masquerading as their guardians.’
+It might seem irresponsible of me to sow distrust and resentment between my brothers, but believe me when I say such matters barely needed my encouragement.
+I doubted anyone did, except perhaps my father, and I was not sure even of that.
+I have no doubt that you will master our favoured weapon, Moses.’
+The Klostzatz’s fire destroyed any vessel that dared to approach head-on.
+The shadows cast by Malkoya’s spires stretched back across the carnage still being wrought after over twenty-four hours of unceasing combat.
+‘Listen to me, son of the tyrant,’ said Agarth, his giant visage glowering at Corax.
+We have blockaded Olympia, and the orbitals remain in our hands.’
+‘My brother does so like to make a statement,’ said Magnus, returning to the crew compartment.
+‘No!’ said Mago as he vaporised another swathe of Ghennans with his serpenta.
+‘Triarch Forrix, send word to the cities of our home world.
+‘You know full well that the champion Ortraxes Falk is my personal guardian.
+The permanent heaps of garbage that choked Nostramo Quintus’ lesser thoroughfares made it difficult to move quietly.
+As Iasus plunged his power sword into the nearest ork, he wondered how long he and his Chapter would continue to move forwards.
+Batto, captain of the Devourers, was the first to come forward to his father’s side to try to placate him.
+Legionaries appeared from both directions of the drainage pipe, Belthann at their head.
+As I boy I was Perturabo, and as a man I shall remain him.
+Every dead child, every society burned, every species I chased from life into history to please you… What are these crimes compared to the truth you kept from us?’
+Mago made to respond, but Khârn raised a hand and closed the distance between them.
+Such things had even been discussed, back in the very first days, but the Khan had ruled against it soon after the first substantive discussions with his Father.
+The man next to Angron dies before his eyes have adjusted to the light.
+Despite the similar livery, they were not of the V Legion, but the 21st Company of the XVI Legion: the Luna Wolves, led into battle by their captain Galkusa Rheor.
+He wondered if the orks were seeking the same kind of destructive sacrifice they had done on Corcyra.
+‘For a long time, I thought you a fool to follow the Emperor.
+DuCaine selected a practice sword from one of the wire baskets at the foot of the cage and tossed it into the cleared ring.
+The third blow shattered his skull, and Gillaneish dropped to the ground.
+Tens of thousands of vital elements needed to go right for the Lux Ferem to get off the ground, and only one had to go wrong for the launch to fail.
+‘Yes, I suppose he might eventually, Khârn, as all mortal things must.
+You brood in the shadows when all you want to do is scream, “Look at me!”
+‘The Lux Ferem needs at least five hundred metres of clear air before she can safely engage her ventral repulsors,’ said Magos Rom.
+‘I could learn the words more quickly if I did not have to wait for Kor Phaeron to read them.’
+He gestured to where the governor sat, chatting gaily with Pyke.
+‘The scale of the interior battles are something more than infiltration,’ Guilliman corrected.
+The Powers move him in strange ways and can you tell me what he is thinking now, after everything that has just happened?’
+Yesugei had been stationed on the home world for some months by then, but for Hasik and the Khan it was still both always familiar and half-forgotten.
+‘Times are changing, Tul, back to the way they were in my great-great-grandfather’s time.’
+‘Wait here,’ said Khârn, gesturing for his brothers to remain outside the cave.
+Bel Ashared raised his bolter in acceptance of the challenge and then signalled for his squad to make ready for the attack.
+Dammekos thinks I will do all this for Lochos, but I am not doing it for this city.
+Not an hour after Fulgrim’s capture of the airship, she’d already had the names of those involved in the poisoning attempt.
+‘Your anger is a clear sign of your guilt,’ said Krukesh.
+He had tried calling to the other Chapters and heard nothing.
+‘A youth will never leave a home he is happy in, Dammekos.
+‘Ulan Cicerus was a passionate rhetorician, and he described the Gardinaal to me in a rhetorician’s terms – they were “big fish in a shrinking pond”.
+‘Now comes the hour,’ Jorin intoned, just as he did on the eve of every conflict, though this time with more than the usual venom.
+‘There is but one city left to bow to the Will of Lorgar.’
+They say it was to be him or Santar to be Clan Captain.
+Fulgrim wondered what Fabius would do if he drew his sword.
+Blessed are we that the Powers turn their gaze upon us.’
+‘One of his sons would seem the logical conclusion,’ I replied.
+Lord Protectors Sho’mar and Kal’ma, I want you and eight companies to join me in the attack on the ork base.
+If He would not share that information with me, I would find it out myself.
+It helped to remember that despite his size and intellect, Lorgar was still a child, and whatever abilities the Powers had instilled into him he remained ignorant and innocent in many ways.
+The grand hololith was dominated by a true-pict representation of Olympia and her attendant satellites.
+A moment later I heard an explosion as one grenade detonated at the top of the ladder, then another more muffled one a couple of seconds later, as he expertly lobbed the second into the confined space below.
+I have noticed that, over time, I have become more able to hold my own thoughts against the tidal wave that is my father’s will.
+To cement this agreement the two factions prayed together, asking the Powers for guidance and protection and strength in the trying times.
+The five legionaries made for Vulkan, intending to fight at his side, but they moved through the orks slowly.
+If the mutineers come back and not us… Well, either we’ll already be dead or I promise I’ll do my best to avenge you and the master.
+It took eight days to implant the Butcher’s Nails into the rest of the Legion within the fleet above Ghenna.
+Remark 73.42.xv: It is the duty of the soldier to accept an order without a rationale being provided, but the absence of a rationale should never be the default condition.
+His thirst for knowledge was insatiable, and he absorbed all that was passed to him as the sands of the White Plains soak up every drop of rain that falls upon their barren expanse.
+‘There is no cause to speak of war and fighting,’ said Lorgar.
+An irradiated planet was a useless planet, save to the drones of the Mechanicum.
+No one there was going to raise their hand against an Astartes, no matter what beliefs they held in their hearts.
+For the first time, Targutai, I have no idea at all.’
+‘Had we waited a minute longer before abandoning Zharrukin, they would have been right,’ said Magnus.
+Only Horus saw the galaxy for what it was, and understood what the Great Crusade really meant.
+He does not see slaves and masters, for there is only the One above to serve, and all beneath are the servants.
+Rather, they take this fact as an unquestioned truth, as self-evident as the truth of the Imperium itself.
+All doubt was forgotten as the Illuminator receded, and the Phoenician readied himself.
+‘There are more – there are always more,’ replied Harkor dismissively.
+His hard green eyes turned to the far rock of the Vaniskray.
+Without a convincing wound, it would have been difficult to get close enough to the Imperial medicae station to use his powers.
+Perhaps they see peace coming in our time, and gather here to enjoy the stability that the Imperium shall bring to the galaxy.’
+‘It is in the hands of the Powers now,’ he declared before descending below deck.
+‘Legionaries of the Eighteenth,’ he said, ‘you are sons of Nocturne, you are my sons and, through me, you are the sons of the Emperor.
+The Emperor led us to Prospero, where we were reunited with our primarch, but in truth I remember little of that meeting or much of what happened in its aftermath.’
+Despite such a prospect, Atharva could not shake the notion they were doing something deceitful by being here, something that might have grave consequences.
+So it was that, slowly, the Imperial Army units were withdrawn from combat, consolidated, then lifted back into the waiting orbital haulers.
+Pray and know that your actions take you closer to the Truth.
+Rogal has made the Throneworld his, in a manner no other pri­march has done.
+The Covenant must endure, but to do so it must also be changed.
+I can’t say I was surprised… My brother was rash, a fool.
+Morning will come, and bring the hot dust, but until then, Angron suffers so that he might give his family some measure of peace.
+He found himself, by accident or design, looking directly at Ferrus Manus.
+The first had come on Terra, when he was a child on the cusp of becoming a man.
+‘Not quite what I had in mind, but it will have to do.’
+‘There are rumours that the government of Lord Balthius has fallen.
+He looked expectantly over his sons, and then finally to Akurduana.
+After compliance, they were tasked with raising fortifications to act as nexuses for future colonies and waypoints for the Legion’s supply fleets.
+‘I do not think the landing is very likely,’ said Saluran.
+I am castellan of the Vaniskray and I will see that it is done.’
+Your writings have taught me how to do so, and for that I thank you.
+‘I have chosen you six to represent the whole of our Legion.
+Standing right next to Axata, it was obvious how large he had become – half a head taller than the chieftain, and still showing no signs of his extraordinary growth abating.
+For instance, it has occurred to me whilst I stacked these last dozen barrels that we might consider it a metaphor for our spiritual labours.
+We used a single Vagabond-class trader, the Argolisa, and drifted quietly into the system along with the regular shipping traffic.
+The Imperium was sprawling and careless, as so many stellar empires before them had been on their anarchic journey towards the pinnacle of their powers.
+‘The Imperium is better off without such fools,’ said Phosis T’kar.
+They burst into flame an instant before impact as Ahriman surrounded himself and Forrix with a layer of superheated air.
+Of them all, he and Sanguinius were the closest to me – not personally, none of them were my friends,’ Curze said sarcastically.
+Even in the Imperial Palace, technological glitches were not unheard of.
+The tunnels of the Fang were full of dangers, all knew that.
+These Lorgar quickly assimilated, and was keen to demonstrate to Kor Phaeron but Nairo warned him not to reveal this to the master.
+That is the cycle from which my Father is saving us.’
+Sitting back with a rumbling sigh, Ferrus turned his face upwards.
+From all around Morningstar, ever-worsening reports were being received of calamitous climate changes, continental-scale earthquakes and magna-storms of such intensity that they scoured the land back to the bedrock.
+Each new day saw the Legion’s astropaths awakened from their chemically induced torpor with screams of exultation.
+‘They will be as my own sons, raised high in the esteem of the Emperor, and bearing his crest.’
+The company had not left the cargo bay far behind when Ven’tal said, ‘Here, captain.
+‘If we are not sure what to make of this extraordinary event, then the Faithful will be even more perplexed.
+Dynat had proved himself to be one of my most capable commanders, and I had left him in overall control of this operation while I executed a front-line role, although in truth there should be very little to oversee given the self-contained natures of our activities.
+That was the first and last time that the Iron Warrior had made Ferrus Manus laugh.
+In places, the meat had been scraped back, exposing the bone, and it was clear that Fabius had been taking marrow samples.
+Though there was little enough of Taranthis to be seen on the surface, the trio of armoured portals that broke the rocky promontory above the mines were imposing enough.
+He, Gage, Iasus and Hierax marched together at the head of the column.
+A glance at the workings gave Agapito a fair estimate of the Sodality’s tech level.
+The Faash were fanatical fighters, wont to scuttle their own ships rather than let them fall into enemy hands.
+A dozen metres away, Forgemaster T’kell had stepped away from a gantry crane and was looking up at the hull with the evaluating, proprietary eye of the true artisan.
+‘Kiner, Kiner, you can hear this, I know it, get yourself up here now.’
+The dust swirled like a miniature vortex in Atharva’s palm, its composite elements spun by the whims of the planet’s increasingly chaotic magnetic fields.
+He studied the Phoenician surreptitiously, wondering if he should speak up.
+Logic dictates that I set aside all emotion and make my decisions based on what is verifiable alone.
+Urien and Morn stepped aside as Strachaan marched through the portal, forced into a stoop to contend with the lintel.
+‘It is blasphemy, to free slaves from bondage laid upon them by the Powers.
+They were set to labour for the Covenant, as willing servants not as slaves, building roads and stations, digging canals and founding convents and monasteries upon the route to guide the Faithful back to the Holy City.
+I rose to my feet, and my body obeyed me as I wished it to.
+We have kept to the faith and this is our time, as was foretold in the Book of Leviathan.
+‘The attempt to speak may be fatal, lord commander,’ said the Apothecary.
+‘And with them I shall fashion peace so that no others must die.
+The duty of controlling the flagship’s long range auspex fell to Lieutenant Vincens Karafee.
+‘I was under the impression I was trying to make you understand.’
+I studied the hololithic globe map of Bar’Savor, which showed the planet as it had been under Imperial rule.
+I had four Headhunters with me – Eltan, Dercius, Jha-Tena, and Hymor – and one member of the Librarius, Akil Gukul.
+‘Then tell them to come out here,’ said Jorin, his voice low.
+‘It is still not clear to me why we require the presence of such individuals,’ Telmar said disdainfully.
+Curze had torn out Elver’s right eye in a night of terror that still made him want to scream.
+‘Did she not know our food and drink are poisonous to humans?’ asked Phosis T’kar.
+‘Of course I did,’ said Phosis T’kar, drawing fresh power into his body.
+‘And yet, when we train them, we do not know where to place them,’ said Naranbaatar.
+They believed that he would expend any resource, even the lives of his own sons, to prosecute the Imperium’s wars, and they were right.
+‘You have no idea what my Legion can bear,’ said Magnus.
+– Fragment recovered from a treatise on Pre-Unification religious mysticism, author unknown
+Or whether, since my Legion and I were perceived latecomers to the Great Crusade, he viewed that he had superiority by means of seniority?
+He was of Irex, regarded as an outsider and rude in manner by his fellows, and for good reason.
+Gukul didn’t move, but I knew he would have closed his eyes behind his helm’s faceplate, the better to concentrate on his mental picture of our surroundings.
+In a history spoiled with exemplary leadership, Lhorke had been a Legion Master without peer, a tactical genius who was always the first to enter battle and the last to leave it.
+The Lion was a monarch, a tamer of beasts, a master of cities.
+He opened his eyes, feeling the strength of the Powers radiating afresh from his body, invigorated by their blessing.
+Three souls sat at the table – the Angel, the Crimson King and the Warhawk.
+‘Did Morningstar ever have an orbital plate like Vaalbara or Rodina?’ asked Falk, still trying to process the scale of what had been built here.
+Aravain frowned, but before he could think whether it would be permissible to ask what the Terran meant, Sathariel gestured to them from beyond the darkened pane.
+Truth be told, Hathor Maat was little better equipped to understand it.
+Lobon, meanwhile, was at least as angry as Sirras over the elevation of Iasus.
+‘Khârn…’ The name barely reaches my ears, anchoring me back in reality for a moment.
+The explosion lifted Herodael from the ground and sent him skimming back up the road like a pebble.
+‘The Terrans are a minority there now too, I believe, but they make up most of the officers.’
+‘Too much to do,’ Jesrin repeated, staring into his screen, hypnotised by its pixelated buzz.
+In another Legion’s council, this might have been cause for outrage.
+I could see mountains off to my right, high and stark, their peaks lost in cloud, but I also knew the plateau on which I sat was already at a high elevation.
+The seismic charge had thrown Numeon and his brothers free of the crater.
+The names were known to all of them: Gamanio, Phemus, Jion, Epihelikon, Chondax.
+The port facilities of Calaena were robust and extensive, but it swiftly became clear that Morningstar’s fleet assets were woefully ill-equipped and insufficient to effect a mass evacuation.
+The astropathic choir has sent word, but all the other Legions are too far from Taras, their forces fully engaged in the Great Crusade.
+But he was their Chapter Master, and when he called, they answered.
+‘No, I do not think you understand what is happening here,’ he said.
+In truth I hope they have, for that will make my mission here easier.
+Another man might have drawn pride from such selfless and repeated service to the Legion, but Pilot Tercio Raylan MqGan was not such a man.
+The urge to strike out on his own had been growing since the discovery of Ultramar, and what Guilliman had accomplished there.
+She poured herself a glass of wine, and then one for Fulgrim.
+The image amused Magnus and he smiled, though even it sent a current of agony through the muscles of his face.
+Although I couldn’t see Gukul’s face, the slight inflection in his voice suggested to me that he was smiling beneath his helmet.
+Their pleas will fall on deaf ears after the centuries of subjugation and disrespect the Covenant has laid upon its neighbours.’
+The Imperium desired the industrial power of the Gardinaal for the Great Crusade.
+The entire population was affected; two hundred thousand Carinaeans now stood against the Legion, along with eight thousand Imperial Army soldiers turned from allies to enemies.
+The night was clear of cloud, lit only by a scatter of blue-white stars above the towering flanks of Krakgard.
+A disproportionate amount of that time had been taken up by Tensat and Belthann exercising their mutual mistrust.
+I fear that I will be forced to destroy what I desire only to save.’
+The delicate looking sabre had been a gift from the armourers of the Ionic Plateau on Terra.
+Men were dying there, it was true, and more than the ritualised customs of war prevalent upon Olympia would ordinarily allow, but his plan would work.
+‘What good are you and your paperskin “Legion” if you need me to win all of your battles for you?’
+He is not Pandion IV, the heir to a legacy stretching back to this world’s founding.’
+For several decades, his dwindled Legion had fought in the shadow of another.
+It was clear that he would have preferred to keep these particular thoughts locked away, but Vulkan had asked him, and he would have to respond.
+The Emperor’s Children were encouraged to test themselves constantly, but the only worthwhile test of skill was against another warrior of the Legions.
+He refused to meet Fulgrim’s eyes, clearly uncomfortable with the giant standing on his veranda.
+Moses muttered as DuCaine began to thump his hands together and encourage the stunned legionaries to cheer.
+On the far side stood Archdeacon Kor Phaeron, as malignant and destructive as the day Nairo had first met him, but safe within the shadow of his adoptive son.
+‘The attack routes are planned, and you will have seen them by now,’ the Khan said.
+‘There are murderers in my Legion too, I regret to admit,’ said Guilliman.
+In the days since their arrival, Pyke’s iterators had fielded hundreds of missives, bearing the seals of an equal number of noble families.
+They demanded respect, not love, and each of the Legion’s machines had their own character, their own favourites.
+The remainder of Nova-Basilos was divided into districts of varying sizes.
+And the fracturing of the Legion had weakened the command structure to a concerning degree.
+My only consolation was that I had trained my Legion well: through them, my legacy would live on, and the Imperium would have its protectors.
+‘Because I know what you know,’ said the unseen speaker, ‘and you know it won’t work.
+Purely in terms of conquest, she ranked high among the warlords of the Great Crusade, though few would admit it.
+Maybe I inherited this tendency for grandiose plans from my real father.’
+The genius for exploiting any opportunity was what had made him the master of Caliban, and still marked his rapid rise through the ranks of the Great Crusade’s most renowned generals, perhaps one day even to rival Horus and Guilliman.
+‘Do you think that mortals should second guess the justice of the Powers?’
+The Khan drained his cup and wiped his mouth before reaching for another flask.
+Greatest and most numerous of all the xenos threats ever faced by humanity, so perfectly evolved into instruments of violence that Imperial scholars had even postulated the wild conjecture that they had been purposely bred for it.
+He flung out his arms, spun around to clear a space and, with a thought, spread the Korvidine Pinions, his marvellous mechanical wings.
+‘I admit, they do move fast,’ said Miltiades, watching the tanks.
+A chant fills the arena, a single word in the lilting tongue of the Nucerians.
+‘Make contact with the rest of the Sixteenth Grand Battalion,’ commanded Anabaxis.
+Knowing that they would be able to live freely under the Covenant, where before they would have faced subjugation, the Epiceans rejoiced for a whole day and wholeheartedly swore their city to the cause.
+‘But the strength cannot be denied,’ said Yesugei, grinning at him and slapping his hand on his shoulder.
+Barely a decade out from its sabbatical on Prospero, the XV Legion fleet was yet to rebuild its full strength and would itself require additional help to ensure as much of Morningstar’s populace was saved as possible.
+‘I’ll talk to the Chapter Master, see if I can scavenge some more meds from somewhere.’
+His name was Felix Tephra and he was the elected spokesman for this horticultural collective on the fertile slopes of Mount Kailash.
+‘Once you’ve formally agreed to compliance, this world will become the responsibility of the Imperium.
+‘For you have betrayed me personally, and that I cannot forgive.
+The commanders of every ship scoured their decks, abandoning all but the most necessary of duties in search of the Legion’s master.
+And Pandion seemed determined to hold onto the throne, whatever the cost.
+From one son, Magnus felt the barely acknowledged fear that his primarch was leading them down into a darkness from which there could be no return.
+‘Once galvanised, they’ll move to take the city, and Pandion,’ Fulgrim said.
+It had been Vadric, in turn, who had inducted him into the Order of Santales.
+‘There will be bloodshed,’ said the First Captain, meaning both from Lorgar’s request and the demand of the Emperor.
+‘The Ultramarines have amassed a long list of conquests, have carved out a great region of the galaxy, and have brought it successfully into the Imperium.
+It was at Nedella that my self-imposed trance broke, and I became fully aware of myself again.
+‘We of the Achaen Hexopolis petition you to join with us and put down these Penthuik dogs that we might have peace again.’
+Carved from the bleak rocks of Uncus, the outermost dot of the Sheitansvar archipelago chain, the Strife-era fortress was formidable.
+On the neatly sectioned decorative paving of the parade ground below, the army of Perturabo gathered.
+When the fireball faded at last, the combined wreckage of the Termite, the girders and the claw formed a mound of smoking, guttering scrap that rose halfway to the ceiling.
+Though they had shared a sublime moment flying the aether, Magnus knew his time here was at an end.
+The conclave table was circular, three metres in diameter, carved from a single piece of Baalite black granite, faintly reflective and speckled with phaneritic points.
+‘Bring us to full speed,’ ordered the interceptor’s commander, a Legion warrior named Othgar.
+After the tale was told, Russ smiled and sat back on his haunches.
+Gathered just outside the gates, standing in silent tranquillity, were the ones who would meet the Legion.
+I have a name, and he knows it,’ he replied, staring at Lorgar.
+‘Lord Vulkan has drawn the greater strength of the enemy to him.
+‘And truth be told, I’ve been dreaming of doing something similar for years now.
+He seemed even younger dressed in the simple pale smock of a Covenant acolyte, the golden skin of his arms exposed.
+I turned to Magos Kunitax, who had been waiting patiently at the controls of the teleportarium.
+‘You’d best thank whatever star you were born under that I have a sense of humour, Abdemon.
+‘I am,’ replied Atharva, and despite his dislike of the legionary, he was elated like a neophyte on his first excavation.
+From the orders shouted by the Chapter Master and the captains, Hierax tracked the rapid shifts in the conflict.
+Chemos had its own slew of folk heroes, including Dig-Operator Jak, and Nimble Tolliver.
+‘Take your units back to High Lord Strachaan as instructed,’ he told the pacifier.
+Lesser iterators, Administratum bureaucrats and military officers of various ranks and privileges.
+Most likely it had been Perturabo, and in that moment Vashti hated him like she had hated no other living being.
+‘No, we have had no contact with Atharva since he left Calaena,’ said Magnus.
+Vastopol was the 14th Grand Company’s warrior-poet, and as such excused watch duty.
+In all things I am your master, Lorgar, while you are my acolyte.’
+‘It is essential,’ said Hasik, wiping the blood from his brow and turning away from the dying sunset.
+‘My orders send me to join the Twenty-Seventh Expeditionary Fleet at Carinae.
+‘Captain Sirras made an error of judgement, one that he could have avoided had he fully applied our primarch’s philosophy.’
+‘Everyone dreams of City’s Edge,’ she said, her voice small yet defiant.
+The Igniax was silent for a short while, thinking through his answer.
+I had already altered the Alpha’s floor plan to confuse any enemy who thought they were familiar with the layout of a Gloriana-class vessel.
+‘Enemy anti-aircraft units are in position to attack the Lux Ferem.
+Forrix looked up and Ahriman saw the acceptance of death in his one remaining eye.
+Phased particle beams sliced into Polar-3 from all sides in such numbers there was more light than black in the void.
+Do you really think my father, the Emperor, having lost His greatest creations to the wiles of His enemies, would have celebrated the rediscovery of the first so loudly, and so triumphantly?
+‘I’ll not give up hope,’ Nairo argued, fighting back the sadness that had seeped into his soul.
+The deep scars where the Apothecaries had cored his flesh to implant his neural plugs still ached at night.
+He was never at the council when Guilliman and Dorn argued over the shape of the Imperium.
+It was ironic, therefore, that Curze had found reciprocal affection for Shang in his black soul.
+The Proteus was stationed at the easternmost edge of the landing zone.
+‘Did I seek to subjugate all of the human species to my will?
+If he said nothing regarding Lorgar the converts and slaves would simply fill the void with their own superstitious musings.
+They had with them heralds who announced them in ringing voices: Ptolemaides, Damek, Krastonfor, Falk, Arestain and a score of other noble names.
+As the Khan trod the embarkation ramp and emerged out into the light of a thousand torches, Yesugei was there to greet him.
+Kor Phaeron pointed at the floor between the door and the cot.
+The crusade is everything, but we hold back sometimes when other Legions do not, for fear of hurting the innocent.
+He caught Erebus looking at him, skull helm held in his hands.
+‘Do you not always say that nothing passes but for that within the design of the Powers?
+She had been presented in tribute to the newly denominated Dark Angels, a gift as worthy as the Leonine Panoply or the Lion Sword.
+As with anything not directly related to war, Akurduana possessed little talent for the victualler’s craft.
+Their best hope comes from following my orders, and they trust I will guide them through.
+The allies of Kardis will soon be on their way here.
+‘Why do you think we give them a head start?’ chuckled Vertanus.
+Everything else – the conquest of the Dulanian worlds, the extension of the Imperium, the long process of compliance and restoration – all of that meant nothing.
+He eased the barriers within his mind, allowing the Great Ocean to seep into his flesh.
+It was an interesting theoretical puzzle, but not one to which I was able to give much time.
+‘Alright, alright!’ grumbled Overton, but he couldn’t quite hide his excitement.
+‘You cannot see him,’ said Forrix simply, and turned his back on them.
+Good: killing his elite, or his closest advisors, would not be the best way to ingratiate myself with the brightest star in the Imperium’s constellation.
+And if He did, it wouldn’t be you – it would be Sanguinius, or Rogal, or Horus.
+If they were able to land artillery and coordinate a concentrated bombardment, they could wipe the surface clean of the Ghennans, and march on to capture Malkoya.
+Now… Now Lorgar spoke of turning the whole world against the Powers with this new religion.
+The Wolf Priest’s eyes narrowed, as he drank in the tomes of data contained in every snapshot.
+House Skraivok’s men – equally well uniformed, for they were an army in their own right – stood guard all around the building, ready for trouble.
+Forrix was an Iron Warrior, a Legion Ahriman knew had little patience for mortal foibles.
+‘A lack of food coming in will affect the stability of Nova-Basilos and the wider continental government.
+Crowds of nobles, generals and the richest of Kardis’ merchants filled the hall.
+While the Gardinaal had retained a number of Dark Age technologies that had been lost to the Imperium, and vice versa, its claim to exceptionalism was its incredible population, and the societal structure that allowed it to be sustained.
+The council chamber on the Invincible Reason had been created to mimic those of Caliban’s ancient fortresses.
+Arriving at the crystal dome, the Space Marines entered through its lone opening and came to a halt at its centre.
+The death of the xenos Titan ran through the khrave’s collective psyche like a fire along a trail of promethium.
+I think, and I know what this sounds like, but I think it is not human in origin.’
+‘My late husband – one of them, I forget which – had a saying.
+Knights of the First hold every strongpoint and critical infrastructure on the Vaniskray.’
+He drew Timur from the body of the final guard and allowed the mortal to sink quietly to the ground amongst his dozen or so comrades.
+His Legion had entered this conflict unprepared for millions of enemies who advanced without any thought of survival and were utterly ­unaffected by morale.
+Destroy the foe by the most expeditious means possible, beset him as swiftly as he was able, and from every avenue of assault: if the Lion could be said to have a single overarching principle of war then it was this.
+‘Did you think that you might best me, Perturabo, in combat?
+Pexx did not ask the Shadowmaster his name, and the Shadowmaster did not offer it.
+The remaining oceans on Chemos were all but empty of life, despite his best efforts, as was the void.
+‘The Sodality see themselves in the same position, threatened by an external foe, only they regard themselves as a greater power than others we have faced.
+His brothers didn’t see it yet – Horus, perhaps, had an inkling – but Fulgrim had grown to manhood among such mechanisms of influence.
+The expression on Perturabo’s face would have been comical under any other circumstances.
+Another Space Marine remained by the pod beside his standard bearer.
+Where was their courage when the time to test the Nails had come?
+Then came the events of Nikaea, and the gradual slide towards catastrophe had begun.
+The situation of the Destroyers was known across the Chapter’s ships.
+‘The libraries of Manraga were well conserved, brother, and its masters encourage broader study.’
+It is with great joy that I see you arrive here.
+Six hours was a long time to keep forty warriors of the Rout cooped up in cramped crew bays.
+Duriel opened his hand and the Lion placed upon it a graven disc bearing a stylised rendition of a Calibanite lion.
+‘After all I have done, where would be the justice in that?
+His wolves were with him, his warriors were with him, and they spilled into the Tyrant’s sanctum like beasts of the dark wood, stinking, their hackles up and radiating distilled aggression.
+If I relied on the strength of others, then how could others rely on my strength?
+The farther you get from Nova-Basilos, the less they pay even lip service to the Gubernatorial Throne.
+‘I was about to say we need to sort this out before the Legion gets involved.’
+The Gubernatorial Triumvirate had been bloodily dissolved in the last set of planetary civil wars.
+That role of standard bearer is one I could never have fulfilled, but sometimes I wonder how heavily that responsibility sits on my brother’s shoulders.
+The minimal share Overton would allow the crew would be more money than they’d otherwise make in a lifetime.
+Corcyra would soon add its name to the tally of lost worlds in the Anteros System.
+‘The nearest Imperial holding is twenty-three light years away,’ said Perturabo, pointing at a star labelled as Haldos.
+To do otherwise moulds a Legion into an inflexible, rote-learned, homogenous mass whose warriors look permanently to their superiors for inspiration.
+The blood of dozens of men and mutants has not been enough, nor is that of two of the Cadere.
+At Lorgar’s command the door hissed open to reveal Erebus, clad in the black robe of a Chaplain.
+This intimate connection between Magnus and his sons allowed no secrets to be kept, no truths to be unacknowledged or desires hidden away.
+‘I just don’t think we should reject Hierax’s approach out of hand.’
+Time was a factor, due to a Space Marine’s rapid healing ability, and so they worked swiftly.
+A great tumult in the centre of the chamber suggested Perturabo’s position.
+And to them all, I give the same answer – it matters not.
+The words were harsh, but Akurduana did not let them sting him.
+The Sharei Maveth would suffer severe damage, yes, but it would endure.
+Not long after, the flag of Lochos rose over the parapets and broken towers of Kardis.
+They were all the invisible cogs of the machine that was the Great Crusade.
+The Lion stirred in his throne and all about him fell silent.
+‘All possible speed to the space port,’ he ordered the Legion.
+A response was received from the XV Legion seventeen hours later.
+Ephrenia had been with Corax since the moment he had been freed from the ice, deep inside Lycaeus.
+Perhaps that was what Niasta had meant about him being the last – the last to survive proximity to that great dark star about which the fate of humanity revolved.
+The Ravens should not have been able to hide so completely, but they had.
+‘I believe it to be some form of navigational instrument,’ said Perturabo, lifting the device to look through one of its eyepieces.
+As far as Aravain was concerned, a final act of mercy for its people was the very least the Dark Angels could offer in penance.
+He moved with an easy grace that Fulgrim suspected came from some form of training.
+The Emperor considered long, as He often did, before giving an answer.
+Their exteriors were crowded by Imperial warships, better showing the huge size of the vessels Corax commanded.
+Most people’s would not, but I was willing to bet there were others who could have managed a similar feat.
+Atharva turned and walked back to the Stormbird and did the same, though he sent the order to his warriors via telepathic pulse.
+Perturabo’s ingenuity had found a way around this, creating novel alloys and engineering solutions that advanced Lochos’ weaponry far beyond that of its enemies.
+‘The Twenty-Seventh Expeditionary Fleet will make an immediate assault upon the Thousand Moons, as per Fenc’s plan.’
+Believe what you may about the lives and rules of mortals, but the Powers exist and they will judge us today.
+The Emperor looked out over the world, as if he could see the smallest detail from their lofty vantage.
+‘Looks like Imperial tech,’ the limping one replied, extending one hand cautiously.
+Kor Phaeron stepped down and Nairo was close enough to hear the exchange between them.
+If we reduce this world to a state of war, then the people will suffer the Imperium’s reprisals.’
+Whatever geological failings Morningstar had as a planet, its people were disciplined citizens of the Imperium and stalwart in the face of adversity.
+The drone was Kiavahran-made, fist-sized and smooth like a bullet; it exhibited none of the mystical nonsense of the Mechanicum.
+Already there were reports of anarchistic attacks on the infrastructure of the farms, as well as a more general agrarian revolt, such as Telmar and Thorn had encountered, along the outer rim of the wider agri-circle.
+Centuries later they had sought then to resist the Dark Angels.
+‘That is true enough, but they would change how the Imperium and the other Legions view us.
+Atmo­spheric frost furred it in sheets that grew thick and shaggy before Elver’s eyes.
+Even now, Fulgrim was making a similar assault on South Barracks, with Telmar and Thorn.
+‘Calm yourself, Kasperos, or I will do it for you,’ Fabius hissed, as he grabbed the other legionary’s shoulder.
+A few months prior to Carinae, Agapito had fought upon a continent plagued by violent hailstorms.
+My desire to prove myself got the best of me, and I made an error in judgement.’
+‘I understand you will be leading my Second Company,’ he said.
+The Lion had his sword drawn, and its grey steel glinted in the cold.
+We are ambassadors for the Truth, you are the Bearer of the Word.
+The blow to his beliefs, to his core of being – to his soul, though the Emperor denied such a thing existed – had been catastrophic.
+Didimus Diogoras, the spokesman of the Penthuik party, seized his chance.
+Previous prototypes of the Nails had run the gamut of entry points for affixing the implants to the subject’s brain.
+Santar roared, furious, breaking a prolonged exchange in which Akurduana’s attention had clearly been elsewhere with a cleaving stroke across the chest.
+‘He has forbidden the use of sorcery within his ranks,’ Yesugei said.
+‘My world was a toxic cesspit before I took it in hand.
+Many Iron Warriors died, thrown from the middle of desperate combat and then back again, their concentration broken.
+Perhaps the rumours are inflated, and Nostramo might be saved,’ murmured Curze.
+He had no sensation of his flesh, no sight of the absurdly fragile silver thread that linked his power to his corporeal shell when soaring in the Great Ocean.
+One of the plays penned by the famed dramaturge of Albia.
+Russ lifted his gaze then, away from the hololith, up at the images, the architecture of Caliban.
+He would look upon these people of Ninety-Three Fifteen with his own eyes.
+‘The Emperor has a plan beyond either of us,’ said Corax.
+The passage that Khârn would follow, though, was easy to choose.
+They were giants, He was titanic: but more in aura than in stature, more in spirit than in body.
+It was perhaps in that moment, as my first independently conceived plan coalesced, that I first felt truly alive.
+‘The Lion wants a full inventory of our capabilities,’ I informed Dynat.
+As if reading his mind, one of the Brotherhood said, ‘If you would help us, we could make this world a fitting gift for this Emperor of yours – a paradise.’
+‘I know, Barban,’ said Perturabo, wrestling the controls as torsion forces tried to twist the gunship’s keel apart.
+The aristocracy had long memories, and a reputation for benevolence would serve a man like Pandion better than an iron fist.
+He looked over at Forrix, his flesh burned to the bone, and reconsidered that thought.
+The face of the Legion was changing, but far more slowly in the Second Destroyers.
+It was the site of my first victory in the unification of Olympia.
+‘You think you are the better hunter, but unlike you I learned something from your battle in the Vaniskray.’
+We shall show the wolves of Luna and Fenris both what true killers look like.
+‘And as death follows life, so rebirth follows death,’ said Shai-Tan, kneeling beside Magnus to sweep the last of the debris from the base of the crater.
+Some would later say that arrogance ruled Kor Phaeron’s heart, but only those who had not known him.
+A figure stumbled out from the flickering darkness towards him, and it took Hasik a moment to recognise the outline of Borghal.
+I would prefer to leave Byzas in better shape than I found it.’
+I had walked through the Imperial Palace before, in disguise, or using my gift to deflect the attention of others, but I had never done so openly.
+His eyes passed over us, and I saw him trying to distinguish between us.
+There was some satisfaction at the fact that they had come for him rather than for DuCaine.
+Rhy’tan felt a sense of purpose that was the same in spirit as the one he had always known on Nocturne, only far greater.
+My brother Magnus can perform feats I suspect only our father can fully comprehend, let alone better.
+Valdor handled High Lord Kandawire’s attempted rebellion well, I must admit that.
+‘Why would anyone not want to leave a doomed world?’ asked Phosis T’kar.
+He hadn’t been, but Fulgrim saw no reason to tell him that.
+I will teach you the Truth – concern yourself only with such lessons as I deem right.
+Kor Phaeron did not emerge from his prayers, studies or whatever activity kept him in his quarters, which suited both the converts and the slaves well.
+But you know as well as we do who the Chapter Master is.
+‘Should we open fire?’ said Vor, his voice thick with the desire to fight.
+‘You do not have the answers you seek, but do the ones I have given suffice?’
+I’d settled on a compromise, which was to ensure that the decisions within my Legion were taken openly, so that even I was not shielded from challenge or question.
+The preacher fixed Axata with a piercing glare, daring him to confess his sins.
+‘Careful, captain,’ said Khârn from the primarch’s side, lending his voice a cold edge with the warning.
+‘Do not use his name against me,’ said Perturabo with quiet menace.
+Violation is the ultimate expression of power, as any poor waif on the streets of Nostramo comes to learn.
+‘They are better than the steam landships the other cities have,’ said Calliphone.
+The pride of the Luna Wolves, those transhuman warriors whose ships lie wrecked around us.
+Now he had a leader who was willing to proselytise with the same vehemence that had set Kor Phaeron onto this journey, a high priest worthy of the office.
+‘We are nearly there, brothers,’ Kal’ma shouted, and he shot his way through the last of the orks before him.
+There were clearly elevator entrances hidden within the city, so as to bring in the Astartes’ ordnance out of sight of those who should not know about it; that was a potential weak point which would have to be addressed.
+Millions of people, every one of them the same hairless, androgynous makeup as the emissaries Ohna had been, ushered forth from behind the walls of their metropolises.
+The bulk of the continental army was on its way back to Nova-Basilos, and the patricians were in an uproar, as their own careful manoeuvrings were thrown into chaos.
+His eyes were rimmed in kohl, and the well-oiled rings of his beard cascaded over his bulging chest in the Selenian style.
+To the Lion, the Emperor appeared as a hooded figure, armoured in emerald plate, inscrutable with gilt and filigree and shrouded in robes of gold, wreathed in obscuring light.
+The final end of this ork empire was preordained, and Hierax deserved his share of the glory.
+It came so close Vulkan could see the tunnels bored into it like those of an anthill.
+‘It has to be this way,’ replied Magnus, placing a protective hand over the book chained at his waist.
+‘If you would bring a primarch into your church, why not try Ferrus, or Vulkan?’ said Perturabo with a sour laugh.
+He liked this brother, but Guilliman had an innate high-handedness he could not disguise.
+But I do know this – the Emperor has a task for us.
+‘Ani, I need you to answer me truly,’ I said to her.
+Since its creation, the Triumphal Hall had been a place of glory for the XII Legion.
+‘I am aware of the potential in what you propose,’ Iasus replied.
+Rare was the occasion when the representatives of Mars would openly share their secrets and methodologies with any outside their order.
+And that meant that Pandion might very well be in danger after all.
+It matters not if it is the hand of the Ecclesiarch or his words that are laid upon them – men and women must be free to speak their mind.
+There were ears that would heed the Word and the Truth, and while they did it was his duty to bring it to them.
+The most uncompromising of the ­Sheitansvar chain, it was the lowest and nearest to sea level.
+Constructed of black stone and glass, the primarch’s personal chambers were cold, hostile and austere, but Ferrus had always found the darkness calming.
+Then Roshan turned and passed a small pouch of coin – a finder’s fee – to Winnika, and Adaram nodded to me.
+Iasus said, ‘I have no wish to injure your pride further.’
+The chromed adamantium cone was immense, larger at its base than a Stormbird and twice as long.
+Alajos and the Lion walked forwards, to the centre of the complex.
+The desire for hope appeared in Rhy’tan’s eyes, though his doubts clearly remained.
+‘The warlord clans of old Albia have been perfecting this way of war on each other for hundreds of years,’ DuCaine explained.
+The thought of Lorgar doubled his grief, for he had lost not only his faith but the only one who had shown him the truest passion and understanding.
+‘Take Telmar and Thorn, and head off those patricians who are advancing towards the city, but haven’t yet joined Bucepholos.’
+Gage began to see the strategy behind the elevation of Iasus.
+As senior captain, Hierax had overseen the elevation of new captains.
+‘As Grandmaster of the Six Wings and lord of the Preceptors’ Council, I knew the nemesis that we might face here.
+The internal facings of the command compartment were decorated with delicately crafted mosaics, depicting representative scenes from the history of the Legion.
+His finger twitched, quicker even than Fulgrim could reach him, and the pistol bucked.
+He could not understand why his relationship with Perturabo should upset him so much, but he returned to pick at the wound over and over.
+The Imperial ships turned slowly, but their engines were far more powerful than the orks’, and as they accelerated once more, they put distance again between themselves and the enemy.
+In this I was mistaken, for the Emperor was, by His very nature, often absent.
+The Khan took his place at the high dais, flanked by his captains.
+The Tower of Infinite Lords was less impressive than its name suggested.
+Some said it was that fusion of devastation and aeons-long patri­mony that had given the Blood Angels their intense aesthetic sense – a reverence for the past, combined with the bitter awareness of history’s callousness.
+The Lycaeans – they were still called that by the guilders – were particularly abused.
+Pro-Imperial sentiment mixed with hostility to the new arrivals, and the refugees became blamed for the pre-existing societal frictions.
+The time would come when the Alpha Legion would demand respect from their brothers, but unlike some of their fellow Legions, my warriors could swallow their pride in the name of a greater goal.
+‘Why should I not remember who I am, and where I am from?
+Ocular-neural implants allowed Vashti to perceive what Rom was seeing, and she winced every time she saw how dangerously overcrowded her airspace had become.
+Bulveye was guarding the throne, bolter drawn, as were most of those Jorin had placed under his command.
+He offers Angron a rag, and the youth accepts it to wipe the dust and congealed blood from his face.
+‘Perhaps his fondness for the eastern empires drew him onwards when he ought to have been more cautious,’ said Ahriman.
+That was the future he had been promised, and it had been delivered to him by Perturabo.
+Fifty of the Legion’s paladins were waiting for them, and they raised their blades in salute as their primarch emerged.
+‘My brothers and I formed a Communion, a gestalt of our minds, and went to Angron in order to calm him.
+Phosis T’kar was a seasoned scholar, but rarely did he ever admit to being in need of instruction.
+But the rest of Vaughn was still lord commander of the XVIII Legion.
+Eye-lenses still slathered in gore, Mago could feel hands grasping at his collar, trying to open the seals and pull his helmet loose.
+‘Remember that what we do here, we do for the Legion.
+Though I’m at a loss as to what it might be.’
+As they drew near, Numeon saw the markings on their pauldrons.
+‘Are you a member of the Order of Santales, brother?’ said Aravain.
+They can tell something is wrong, even if they can’t define exactly what, and they bark challenges as I approach.
+The main attack of the Ultramarines swept over them like a volcanic blast.
+Axata said nothing as he followed Kor Phaeron along the companionway and up the steps to the main deck.
+His loyalty to the Legion and the primarch’s vision did not fail.
+Gases ignited, and billows of fire rolled over Vulkan as he marched towards the obelisk.
+He had known in that moment what Kor Phaeron meant when he said that they dwelt beneath their immortal gaze.
+‘What I saw… It was an apocalypse of man’s own devising.’
+He opened his eye as the sound of roaring engines screamed past the Stormbird.
+Kardis is but the first, and before I am done, all Olympia will throw itself to its knees and beg for forgiveness.’
+They were not far from the Red Level, the place where in blacker times the wardens of Lycaeus had tormented their prisoners.
+‘I confess some curiosity as to the nature of your preparations, Lord Fulgrim.’
+Horus was the first of the primarchs to be recovered: he was found on Cthonia, merely three years after the Great Crusade commenced.
+Russ erupted into a howl of fury, swept up to the Lion with a sudden surge of speed and landed a huge, clenched fist into the heart of his brother’s breastplate.
+Such a fate would be denied forever to him that day, as he was taken from the world he knew, and placed within that of the Legion.
+Already the Avernii Clan formations under Akurduana were catching up to their bitter rivals from Clan Vurgaan.
+A flat plane of silver extended before the Space Marines for a kilometre in every direction.
+In that instant, Russ had an insight into a wholly alien way of battle, one of long-gestated plans of conquest, of moderation and tactical restraint, ready to turn preserved resources back towards the service of a greater humanity.
+Thus, the mood amongst his children in the Practice Hall was black.
+‘The Holy Church of the Covenant extends to where its servants are, and as we are all ordained priests of the Covenant that means these are holy lands.
+Fulgrim had been silent since they’d left Patrician Bucepholos’ coastal holdfast.
+‘Compliance is not solely about forcing worlds to surrender the sovereignty, Belleros.
+The Khan looked at his brother warily, as if cautious to avoid some kind of trap.
+It was he and Thias Herzog who had first suggested cosmetically altering their appearances to mimic my own, thereby allowing me to move more freely within our Legion even if my identity was discovered.
+He subtly closed the pain gates in the Iron Warrior’s spine, hearing a groan of relief escape his scorched lips.
+I’m going to show you what I need, and you’re going to do it all within a standard year.’
+‘I understand… There has been a…’ Again, she hesitated, mouth working slowly as she stared at the ruined corpse in front of her. ‘…a new plan.’
+There was enough consensus in the fragments to gather some sense of the systems’ histories during the Age of Strife.
+‘If I am to call you Fulgrim, you must call me Belleros, please.’
+No sooner had the words left his lips than he felt a flare of emotion from Hathor Maat.
+‘You Iron Hands claim to be so logical, so tell me, brother, is it logical to assume that a man with a few scars is a better warrior than one without?’
+In Raylan’s mind, a close, black nebula cloud passed from the face of a bright, loving star.
+The coastal enclaves of Chalkedon were, by and large, devoted to aquacultural pursuits.
+The boy joked with the converts and slaves, and constructed elaborate fables from their histories, spinning truth into fanciful adventures through the divine realms of the Empyrean.
+In the past week, Pyke’s subordinates had run themselves from one end of the planet to the other, collecting data and making themselves seen.
+Guilliman took a third of his infantry below, leaving the Invictarii to command the rest and direct the final annihilation of the orks at the surface.
+‘I think I have had just about enough of you, Apothecary.’
+‘Then if not from the gods, where are you from?’ asked Dammekos.
+These people are neither simple nor stupid, ­Frazer’s assumptions to the contrary.
+‘I thought I had seen all there was to see in this galaxy.’
+Another legionary, Reicun, replaced the removed section of wall and held it in place while Qvova took out a canister of ferrofoam and sealed around it.
+You need only know that Vharadesh is both the paradise of the Powers and the hell of mortals.
+This last statement was too much for the Lord of Iron.
+The armed forces of Trulla had a preference for high-powered energy weapons that were devastating when they hit, but also had a tendency to set fires when they missed.
+He was simply very old, and in spite of that a proud patriarch of Lochos still.
+In Iasus’ few interactions with him, he had been almost completely silent.
+The suite’s central room was square, cloistered around the edges but open in the centre to a high ceiling decorated with a moving cloudscape in reference to the enclosed courtyards common on Guilliman’s home world.
+It turned out I could be quite convincing, when I wanted to.
+‘Tailor our fighting style to best complement that of the Dark Angels, so far as possible.’
+He knew that the aid of the Emperor’s Children had been invaluable, in regards to certain military efforts.
+‘Hierarch-vizier Jusua and his missionary caravan were ambushed in the Valley of the Red Queen.
+Now I strode through its streets wearing the armour of the man I had killed, and marvelled at how inconspicuous a giant in gold could be.
+And you should understand that finding myself here was not what I expected.
+His voice broken by grief, he spoke of the Unification of the Central Afrik, and the first time he had crossed paths, and swords, with a brilliant young captain by the name of Akurduana.
+He nodded briefly to Vaughn and bent back down to the work of amputating the left leg of a still-conscious legionary.
+The Wolf King isn’t a fool – he knows this just like we do.’
+He flicked his hand away, and Khârn heard the soft patter of blood scattering across the floor.
+Vulkan had achieved the perfection every warrior of Nocturne sought to embody and, by his example, inspired all to the ideals he made manifest.
+‘Do you think they would poison their own civilians?’ asked Milontius.
+And on the vox, all he heard from the chamber with the Spear of Fire was the shouts of more brothers, the thunder of explosions.
+‘I still hear the dead of Morningstar screaming,’ said Magnus, clawing a handful of ash from the crater within the Pyramid of Photep.
+Its layout was typically pre-Old Night, the buildings bespoke, the conurbations sprawling, lacking the enforced standardisation and brutalist symmetry of an Imperial colonisation.
+None of us like Curze, and he appears to despise us all, along with his own Legion.
+It was dark as the Night Lords preferred it, lumens dimmed so low the multitudes of serfs working there needed lamp packs to see.
+His pack formed up around him as more survived the trials: Valgarn, Eiryk, Yellowtooth, Sventr and others, all young, their skin smooth and their eyes shining.
+He had been thinking of the long-term transformation of the Chapter when he had spoken with Sirras.
+In keeping with his role as Ferrus’ shadow, Akurduana had held his silence until now, saying or doing nothing that could contradict the primarch.
+The Ultramarines formed into tighter, smaller, more mobile formations, unbreakable stones in the midst of the ork torrent.
+A single Nucerian day, thirty-one of your Terran hours, was all we needed to earn our victory.
+We had our own agenda; that fact would need to be concealed from one of the most perceptive beings in the galaxy, and I am one of the most talented liars ever born.
+The Powers instilled in you some fate greater than that of any mortal.
+Tull supposed that a little radiation posed no hazard to Ulan Cicerus.
+I relaxed my guard stance, although I did not take my eyes off my opponent, even when I inclined my head in a small bow.
+The Lion’s smile was a fleeting thing, far above the ability of any there present to see it for what it was or decipher its true meaning.
+But I was hoping I could have a word with the primarch about it.’
+The Stormbird vibrated with potential, the pilot keeping it on the ground with a light touch, ready to lift off in an instant.
+The whole campaign looked, on the surface, to be pointless, though Dantioch was not a warrior to see the surface of anything – be it metal, stone or an idea – and judge it upon that merit alone.
+The only thing he believed in more than the Word and the Truth was the persistence of enemies.
+‘And I will see his works come to full fruition,’ Kor Phaeron assured them.
+I never wanted that, but I did it, for I have grown weary of fighting with my own brothers, and there has been much to rebuild and remake.’
+The Byzans kept them running more through luck and determination than any true understanding of how they worked.
+‘Fear not – I have no wish to deprive you of your promised trophy.’
+Even so, he would not open this particular discussion with Marius.
+Intep Amar of the Thousand Sons was huge in full armour, as red as freshly spilled blood and just as frightening.
+‘I trust Abdemon has seen to your needs adequately on the journey?
+‘Pech,’ I called, and Ingo Pech increased his pace to come alongside me.
+‘I’ve been wondering the same thing,’ said Hathor Maat, appearing at Atharva’s side and scanning their desolate, empty surroundings.
+Seeing Corax’s expression flicker distaste, Guilliman, ever the statesman, continued smoothly, ‘But you are also similar to me.
+He rose to his feet as a suffocating fear arose in Magnus, a sensation he had not felt since...
+‘There are no oceans left on Terra,’ said Stenius, ‘and yet we still tell ourselves tales of captains driven mad and ships lost without trace.’
+Besides Fulgrim, he alone fully comprehended the chasm the Legion had only just skirted the edge of, and how easy it would be to slip into it, even now.
+‘Lord Corax did try, but the Xeric tribesmen who made up most of the old Legion were too wild to tame.
+‘There are people who would call me a traitor for speaking with you,’ Tensat said.
++My lord?+ Phosis T’kar sensed his master’s damaged presence and was instantly aware that something singular and profound had occurred. +Are you… hurt?+
+Nairo heard scattered mention of the names of cities – settlements that had been brought into the dominion of the Covenant.
+Similarly, the multiple requests for remote audience sent by Admiral Fenc went unanswered.
+A scattering of Iocare’s Legion kin had gathered to observe the procedure, arranging themselves in loose rows around the wide banks of armourglass outside the apothecarion.
+This was, after all, a warrior whom my father had selected as one of His own, had meticulously gene-crafted, and into whom had gone considerable resources in terms of training and equipment.
+He directed a meaningful look at Kor Phaeron as he continued.
+In many ways, they were far more diverse than the Dark Angels behind whom we walked.
+A tiny bead of liquid slid down Ohna’s neck, but it was not the deep, vital red of human blood.
+Among the rediscovered sons of the Emperor he was among the tallest, though not as heavily built as his guest.
+The cheers of the crowd had ebbed as they got their first look at the towering forms of the Space Marines.
+‘I do not know if this person is me,’ said Perturabo mildly.
+‘I wished to find their Librarian, but no one can tell me where he is.
+‘I like you, captain,’ said Angron, cuffing away at the blood trickling from his nose and baring the iron pegs that replaced his teeth in a feral grin.
+A bolt of flickering plasma took one of Zolan’s men in the chest.
+‘Tell me what happened here,’ said Magnus with a slow and measured tone.
+He wanted the old warrior to do more than watch; he wanted him to see his worth, to see how his plan would overcome their old ally and open the continent to the domination of Lochos.
+‘Well said, brother,’ said Holguin, just as Stenius walked up the steps to the dais.
+The Lion turned them over and unsealed them, taking a second to absorb them fully.
+I recognised the thing next to me as the remnants of what had surrounded me, in the dim, swirling memories that were all I had of my life before that point.
+He is the Khagan, the conqueror of conquerors, and you will be his blood-kin.
+‘We only knew you as the Wolf King, son of the Allfather.
+‘More time accounts for only part of your skill,’ said Corax, recovering some of his good humour.
+The other Legions I have served with had a stronger presence of warriors from the Throneworld.’
+For a moment, I was not sure how he was going to react.
+‘On this day, brothers,’ the Khan said, ‘we show them the storm.’
+‘It has been said that the Lord of Ultramar sees little else besides the primacy of his own culture.
+The flagship of the Blood Angels Legion was as much an object of beauty as an instrument of war.
+If you will not serve this Legion and the Emperor as free men, then you shall serve me in chains.
+‘That old woman, as you call her, is a respected diplomat and a member of one of the oldest noble houses of ancient Terra.
+The Khan looked at her a little longer, considering whether to press the question.
+Even so, the vehemence of Sirras’ tone coupled with how quietly he was speaking made Hierax uneasy.
+The sheer calculation required to manually bend a Legion to one being’s command was mind-breaking: several hundred ships, a hundred and fifty thousand warriors, tens of millions of ancillaries, auxiliaries and mortal support staff, all of them scattered across scores of distant warzones.
+‘I have thirty thousand Legiones Astartes here, in this system,’ said Corax.
+We can throw everything into keeping the orks here, away from the Taras System.’
+Many of the Destroyers wore raptor icons suspended from the belts at their waists.
+‘She has been impounded by the Wrath of Caliban and nothing more has been heard of her since.
+His flesh was pellucid and incandescent, an angelic form to equal anything born of Baal.
+You will do what you must to preserve what we have built, even without instruction, even if…’ He trailed off, and sighed.
+‘I don’t know exactly what that means, but I swear no harm will come to you while I watch over you,’ promised Forrix.
+The plastered walls were painted with elaborate murals that reminded Kor Phaeron of illustrations from the oldest holy books of Colchis – depictions of the Empyrean he had studied for long years before the arrival of the Emperor and the XVII Legion.
+Silence fell across the plaza, and Fulgrim felt a small thrill of pleasure.
+I had not told either him or my father where I was going, or what I intended; indeed, I had deliberately been shielding my thoughts from him.
+Not one of the atrocities I have committed can possibly compare to a lie of that scale.
+Across the Ullanor Sector, fortresses were toppled, fleets put to the torch, tyrants cast down, glory cut from the heart of the mightiest of humanity’s foes, and every victory brought the Emperor and Horus nearer to the throneworld of the last great xenos empire.
+‘You should keep a better count,’ Abdemon said, lifting his sword.
+This was not how he had imagined being a member of the Legion to be.
+‘There are other parties who believe your priesthood is destabilising the guilds itself,’ said Tensat.
+‘Where is your captain?’ asked Mago, spurring his company on to fight their way closer.
+The more of us that are found and the more time I spend with our brothers the more astounded I am by the majesty of the Emperor’s plan.
+Pneumatic bombards and electric hyper­velocity guns of the sort not seen on Terra since Old Night.
+For a moment even Jorin’s eyesight struggled to compensate, and for a half-second it felt as if he had been hurled into the void.
+The Raven Guard weren’t the only ones in the sub-system with infiltration skills.
+When I was penetrating the Imperial Palace’s security, I was relying only on myself.
+‘What are you?’ said Karzen, his fear pushed aside by unexpected awe.
+‘There were so many people who fought for me against the overseers of Lycaeus,’ said Corax emotionlessly.
+They’d signed their own death warrant: Eltan and Dercius would swarm the vehicle before it could move again, and would swiftly eliminate the occupants.
+‘No man has the right to take freedom from another,’ Corax said, in the argot of Carinae.
+The instinct to protect the home world was ingrained in the very being of every native of Nocturne.
+The only sign of the warrior’s near death was a slight limp, but Ahriman saw a dark halo wreathing him, an effect that ancient shamans had known and feared as a death mark.
+When the last of the mob went down under a hail of shells, Guilliman looked at the legionaries before him.
+The walls of the crevasse shook and Numeon heard the hiss and crack of rock melting and falling below.
+I am Chancellor Corynth of the Continental Government of Chalkedon-et-Byzas, and I extend to you the hospitality of the Gubernatorial Throne, and all the protections and rights thereof.’
+‘I will remember that, my master,’ said Lorgar, with a quiet vehemence that set a flutter of agitation in Kor Phaeron’s chest.
+‘What if it does not work as anticipated, my lord?’ said Tzurin.
+The Blood Angels had housed them in a tower complex in the northeast corner of the enormous fortress.
+You will swear by the Powers that you will be a defender of the Truth.
+He was too wise to call the First Captain’s plan out for idiocy, but put his concern into the tone of what he said.
+For many it is what binds them to you, to the Imperium.
+The more I see of the Crusade, the more I see its weaknesses.
+‘I come in the name of the Emperor of All Mankind, Lord of Terra and All Known Space, to welcome Byzas and all its peoples at last into the Imperium of Man.
+The subaltern’s voice was frightened enough to distract Perturabo from his screeds of data.
+The new constitution was written in fine handwriting on creamy paper soft as water; Nostramo’s violent nature distilled into beauty.
+The chill of the ice world became the chill of the empty Palace, and the sunlight faded to the dull grey of Terra’s winter.
+Ferrus could no longer even visualise him without seeing the radiance of the Emperor upon him, their father’s favoured right hand.
+‘I have created an archive for you, so that your achievement may be recognised for posterity – the Library of the Primarchs.’
+The sadness was hidden away again, so that Perturabo doubted he had ever seen it, and was ashamed he could impute such an emotion to so perfect a being.
+If I can acquire enough, I will build a weapon of such awful potency that it will end war on Olympia forever.’
+The captain sighed as a sudden fireball consumed the Thunderhawk and its escorting fighters, drenching his pale, hideously black-veined face with light.
+It matters not that you dwell in the wild places, cast from civilisation into the desert like animals, for we are all nothing but tenants on the lands of the Powers.
+Unlike Hierax’s wounds, which had accumulated over the length of his career, the mark of Kletos’ injury had come all at once.
+He raised the Hand of Dominion, and he answered the orks with a roar of his own.
+Next to Orasus were three others who had all served, at one time or another, in squads commanded by Numeon before his elevation to first captain.
+One of the Luna Wolves, inspired by that vision, tried to join him then, to add his blade to his, and it took Qin Xa to hold him back.
+‘But they exploit division and weakness and I find only brotherhood and courage in the soul of the First.
+Besides, they would have targeted military installations, ammunition dumps and communication relays, not memorials to fallen heroes, or the statues of the First Founders.
+‘Listen, father…’ Kor Phaeron winced at the use of the patriarchal title.
+The magnetically pressurised jets of plasma ejected by the weapons of the Dreadwing were flames that burned many times more violently than the hottest star.
+‘By your will,’ said Alajos, sending the order to his assembled paladin squad via the closed comm-link.
+Such had become his skill with languages and linguistics, the Ecclesiarch needed only to spend a day in the presence of a native, or to read a handful of the texts of the faithless, to understand their idioms and beliefs, their culture and morals.
+‘We should fight together again, you and I,’ Horus said to the Khan.
+He understood now that the duty to protect was not limited to Nocturne.
+Every decision Hereditary Governor Pandion made likely required the agreement of one or more of the families.
+‘Do please try not to collapse the mountain on us, first captain,’ said Caelius.
+This way, in the event that his father lost control and disappeared into the depths of the Conqueror, Khârn and the Legion would be able to find him.
+‘They were not ready for you until this moment, and you were not ready for them,’ the Emperor told him.
+There are different versions all over Colchis, from every converted city and tribe and pilgrimage.
+He is a primarch, Armillus, and therefore the embodiment of the Emperor’s will, and his Legion are blessed to have him.’
+The Gardinaal claimed they knew him, but no one knew him.
+Well, in that case, I’m surprised there’s only one of you.’
+‘Beneath the masquerade of the Covenant there are sects and cults still dedicated to the Powers.
+The Iron Warrior was wreathed in the corrosion and dust of an unending war fought in the darkness of a far future.
+I’ve had reports of local armour being deployed against the Nigris bridge-forts and of infighting amongst the fort’s defenders.’
+He was not of the Two Hundred like Abdemon or the Spider, but he had fought and bled alongside humans for decades.
+‘Thank you for your aid,’ I said, as I reached them.
+But the apothecarion was beginning to flourish anew, under Fabius’ somewhat distracted care.
+Sometimes talking to her felt like reporting to the entirety of the War Council.
+I simply need to know which planet you were evacuated from, and then I can leave you in peace.’
+Do I need Captain Akurduana to take every opportunity to demonstrate the frailty of my Legion as well?’
+Dorn or Perturabo will tell you that a structure can only be as strong as the materials from which is it made, and yet no one seemed to apply the same logic to a society.
+The road ahead would be dark, and bitter, but he would do anything to preserve the Legion.
+If you have something to say to me, I would be grateful if you could say it and then leave.’
+‘If Magos Tancorix can develop an inverse algorithm capable of breaking down the mathematics of these flows...’
+Do you know what the Twenty-Eighth Grand Battalion did to Irex?’
+Forged from pure ores, drawn from deep veins and shaped according to the traditions of the Sulpha people.
+It was Kor Phaeron’s role to guide him to that conclusion.
+‘Now this is something I could make use of,’ he murmured softly.
+Her people were pariahs, even among the workers of Kiavahr, who were almost as oppressed.
+‘The wrong way,’ argued Kora, Fabri Tal’s elder brother, who had already expressed his favour for the plan of Fan Morgai.
+We endured the long aeons here when Terra was but a myth or childish dream.
+You must learn to pay more attention if you are to seek the Truth.
+‘What will you do?’ asked Eugon Ptolemiades, whose city Kardis was.
+At that moment, hanging over Ynniu, he observed the product of his Legion’s mastery of violence.
+‘They will make contact with our operatives on Volda Beta to find eyewitnesses and verify the truth of these claims, as well as getting an exact location of the sightings.’
+Now I relied on others: those I’d trusted and trained, or those they had in turn trusted and trained, and so on.
+‘But these are not commands, are they, truly?’ the Khan said.
+To overthrow him, to replace him with a council of unknowns, or worse, a group of men the common people of Byzas hated, was to risk planet-wide upheaval.
+What had once been the seabed ripped wide open, and the burning sectors of Attar tumbled into a hellish fiery chasm.
+It was as if Antaeum had spat out a monster forged from fire and rock and animalistic rage.
+I taught that all men and women were equal beneath the gaze of the Powers.’
+But he had turned the battlefield over to Numeon, and that decision was the right one.
+The Lion looked no better – his cloak hung about him in greasy tatters, and his shoulders were slumped.
+He and his company had passed through the furnace, as Vulkan had done, and brought destruction to the orks at the moment the xenos had believed their victory in hand.
+‘You could have told me that I worked at the same mystery as my brothers,’ said Duriel.
+I pass it to you, for the Powers have spoken and declared that the message must be heard.
+Even through the nightmarish storms, Perturabo – and Perturabo alone – could still see the distant star-maelstrom, its unnatural energies swirling like a whirlpool in a stagnant ocean.
+‘Kor Phaeron’s elevation by my efforts in no way diminishes my achievements.’
+The Imperial stated it matter-of-factly, no hint of boastfulness or exaggeration.
+He waited for his brother to approach, the Lion Sword in one hand, the evidence of his kill in the other.
+Where Kardis had once stood there now blazed a firestorm haemorrhaging black smoke under a dispersing nuclear cloud.
+The Dark Angels fell back from the wall in stages, using the flames and debris as cover.
+Here, at one of the highest points of the Vhanagir desolation, snow was more common than rain, but it was not yet the season for such bounty from the Powers.
+Fragments of the chains with which Curze had bound him to the seat still hung there.
+He doubted the others in the Seventh Tactical Squad felt the same trepidation he did.
+‘A long time ago, you told me what you had learned of your coming to Fenris.
+And yet, my brothers and I can go against the Emperor’s wishes, even when we do not intend to.
+There was Ev Tenn, not four metres away, one of the few men close to his own age at the function.
+He fetched the water ewer from the table and handed it to Lorgar, who drank from it as though it were a cup, downing the contents in two mouthfuls.
+Within an hour of the assault’s commencement, half the city was under Imperial control.
+Vharadesh stands ready to receive its true lord, Lorgar the Bearer of the Word.
+Barban Falk had emerged from the fighting, dragging the bloodied, struggling form of Konrad Vargha behind him.
+The reduced Twenty-Seventh Expeditionary Fleet returned to Kiavhar under Corax’s command.
+That statement troubled me, but I had no more time to reflect upon it, for we had reached our destination: a dark door with local numerals scrawled on it in white paint.
+It could be a small band of malcontents, or even an individual, though I admit that’s unlikely.’
+They were all XVI Legion, though seemingly from many different squads.
+The Emperor’s disregard for Lorgar, His contempt for the great work done in His name, provided opportunity.
+It was huge, too great for any mere Space Marine to operate alone.
+While Nova-Basilos was firmly under the control of the continental army, Fulgrim was not so foolish as to leave the Hereditary Governor completely unprotected.
+The haste of our departure from Vesta necessitated that the bulk of my Legion and all of its mortal auxiliaries be left behind.
+Guilliman and Dorn, by contrast, were masters of their own realms.
+The Rout had been thorough, as ever, enacting a tactical sequence drawn up while in the warp from Galamandro, but even then the losses had been significant.
+‘Make no mistake; I can do all that I have said and more.
+‘I should be able to see what it is that makes them love Him.’
+‘Does it really matter if I’m in one piece when you kill me?’
+If she had been operating entirely from a position of rationality, she would have been nowhere near the bomb when it went off, but Phelinia was far too invested emotionally in liberty’s struggle for that.
+I was using my gift again, but I would still be a tall, powerful shape in their minds.
+Elver drank in knowledge unfiltered, comprehending suddenly and completely that Curze only half-believed what he said.
+He exuded such a high level of threat that Elver’s teeth and bladder ached with his urge to run away.
+‘They still do not have enough warriors to conquer us all,’ said Hord.
+They needed overwhelming numbers to tilt the battle in their favour, and for now, Resalt had succeeded in carving out a space for her vessel.
+The lava had pushed the Legion’s heavy armour together in a great hill of ruined metal.
+A significant minority of Curze’s fifty ships had been resistant to the primarch’s orders.
+It was hot, almost as hot as Baal had been, though he did not know whether this was from the munitions unleashed in the atmosphere, or because Ullanor had always been that way.
+The colour drains from Hexx’s face, his lips speckling with the pale blue of the newly dead.
+The situation was the same as it had been over Corcyra.
+He had been ­honoured to do so, and he had found true kinship with the Iron Hands of Ferrus Manus.
+‘We have been told you might have seen something remarkable, before you were evacuated,’ I said softly.
+Stenius, though he masked it as well as any lord of Caliban, was assuredly one of them.
+A new shadow appeared, stretching over Khârn where he crouched atop his mutilated kin.
+Caelius was an observer of the bleak humour of war, while Blasius was taciturn but relentless.
+Caution warred with expectation across Vaion’s aura, where a clinical calm permeated Korit’s.
+The orks of the Thoas Empire had taken Machon’s head in the final stages of the campaign to purge them from the Aletho system.
+I’d made it home, grabbed Sev and Seddy, and we’d run for the space port.
+Fan Morgai said nothing but swallowed hard, meeting Kor Phaeron’s gaze for only a moment.
+‘Until now you were no man’s servant save the Emperor in this place,’ Hasik said.
+‘I thought you wanted to help,’ Lorgar said with a pout.
+Azkaellon and the Khan regarded one another and both seemed satisfied with what they saw – warriors of the most strenuous breed, immaculate and uncompromising.
+He was the master of the Horde of the Earth now, a commander of thousands of the finest troops ever created, a conqueror of worlds and a scourge of empires.
+And we did it again, at Brujo, and Holu, and Trikaton, and Cestus Four.
+But the Khan had not sent his sons blindly into battle.
+However, neither could do anything about it, and so like all in Lochos, they played the parts expected of them in the great tragedy of life.
+‘I do not work with fools, even pleasant ones,’ Fulgrim said.
+‘The only thing that burns in Hell is the part of you that won’t let go of life: your memories, your attachments.
+The 22nd Chapter was operating at the northernmost edge of the Ultramarines front.
+Then Vaughn was falling as the beast was swept up by the molten rock.
+But I have also seen him before those battles, and after them.
+It had been much the same on Chemos before his ascension.
+I barely take orders from my Father, let alone anyone else.
+You speak, too, from your heart, as I am forced to do now.
+They formed firing lines in the wider halls and avenues, shutting off major access ways with tanks and Dreadnoughts ordered to kill anything that moved on sight.
+Vaughn was in the base, replenishing his ammunition, when Xerexenia contacted him over the vox, asking for an audience in the command centre.
+Why does Regent Ikthileon not present himself, and stand here now to make account for the silence of Ninety-Three Fifteen?’
+It still couldn’t touch the agility of a Xiphon, and even if it could, no mortal pilot could pull off the aerobatics that a Space Marine was capable of.
+I merely punished those who had wronged, just as your false Emperor now seeks to punish me.


### PR DESCRIPTION
The Warhammer 40k dataset contains sentences from books (science fantasy).

EN->DE subset (v0.1)
2000 sentences in English